### PR TITLE
fix: 修复 Windows NapCat 重连与实时日志同步

### DIFF
--- a/cmd/clawpanel/main.go
+++ b/cmd/clawpanel/main.go
@@ -359,7 +359,7 @@ func runServer(stopCh chan struct{}) {
 		api.GET("/workspace/preview", handler.WorkspacePreview(cfg))
 
 		// 外部日志接口（无需认证）
-		api.POST("/events/log", handler.PostEvent(db))
+		api.POST("/events/log", handler.PostEvent(db, wsHub))
 	}
 
 	// WebSocket 路由（前端连接 /ws?token=...，需通过 JWT 验证）

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,9 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// Windows 服务场景下避免误落到 systemprofile
+	cfg.OpenClawDir = resolveOpenClawDir(cfg.OpenClawDir)
+
 	// 路径校验：
 	// 1) 如果配置中的路径是另一个 OS 的路径格式，则重新探测
 	// 2) 如果是相对路径（历史版本遗留），统一升级为绝对路径
@@ -303,7 +306,7 @@ func (c *Config) ReadOpenClawJSON() (map[string]interface{}, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	cfgPath := filepath.Join(c.OpenClawDir, "openclaw.json")
+	cfgPath := filepath.Join(resolveOpenClawDir(c.OpenClawDir), "openclaw.json")
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, err
@@ -320,12 +323,50 @@ func (c *Config) WriteOpenClawJSON(data map[string]interface{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	resolved := resolveOpenClawDir(c.OpenClawDir)
+	if resolved != "" && resolved != c.OpenClawDir {
+		c.OpenClawDir = resolved
+	}
 	cfgPath := filepath.Join(c.OpenClawDir, "openclaw.json")
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(cfgPath, jsonData, 0644)
+}
+
+func resolveOpenClawDir(current string) string {
+	if current != "" {
+		jsonPath := filepath.Join(current, "openclaw.json")
+		if _, err := os.Stat(jsonPath); err == nil {
+			return current
+		}
+		if runtime.GOOS != "windows" {
+			return current
+		}
+		lower := strings.ToLower(current)
+		if !strings.Contains(lower, "systemprofile") && !strings.Contains(lower, "system32") {
+			return current
+		}
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, userHome := range getWindowsUserHomes() {
+			candidate := filepath.Join(userHome, ".openclaw")
+			if _, err := os.Stat(filepath.Join(candidate, "openclaw.json")); err == nil {
+				return candidate
+			}
+		}
+		legacy := `C:\ClawPanel\openclaw`
+		if _, err := os.Stat(filepath.Join(legacy, "openclaw.json")); err == nil {
+			return legacy
+		}
+	}
+
+	if current != "" {
+		return current
+	}
+	return getDefaultOpenClawDir()
 }
 
 // isStaleOSPath 检测配置文件里的路径是否来自另一个 OS（跨平台路径污染）

--- a/internal/eventlog/listener.go
+++ b/internal/eventlog/listener.go
@@ -49,6 +49,8 @@ func (l *Listener) Start() {
 		l.mu.Unlock()
 		return
 	}
+	// Recreate stopCh in case Stop() was called before (channel is closed after Stop)
+	l.stopCh = make(chan struct{})
 	l.running = true
 	l.mu.Unlock()
 
@@ -291,6 +293,9 @@ func (l *Listener) parseMessageEvent(msg map[string]interface{}) *model.Event {
 
 func (l *Listener) parseNoticeEvent(msg map[string]interface{}) *model.Event {
 	noticeType, _ := msg["notice_type"].(string)
+	if noticeType == "notify" {
+		return nil
+	}
 	summary := ""
 
 	switch noticeType {

--- a/internal/handler/bot.go
+++ b/internal/handler/bot.go
@@ -214,18 +214,70 @@ func napcatProxy(method, path string, body interface{}, credential string) (map[
 	return result, nil
 }
 
-// readNapCatWebuiToken reads the actual token from NapCat's webui.json (Docker or Windows Shell).
+// readNapCatWebuiToken reads the actual token NapCat is using.
+// NapCat 4.x generates a random token on each startup and logs it as:
+//   [WebUi] WebUi Token: <token>
+// So we parse the latest log file to get the live token.
 func readNapCatWebuiToken(cfg *config.Config) string {
 	if runtime.GOOS == "windows" {
 		napcatDir := getNapCatShellDir(cfg)
-		if napcatDir != "" {
-			data, err := os.ReadFile(filepath.Join(napcatDir, "config", "webui.json"))
-			if err == nil {
-				var webui map[string]interface{}
-				if json.Unmarshal(data, &webui) == nil {
-					if t, ok := webui["token"].(string); ok && t != "" {
-						return t
+		if napcatDir == "" {
+			return ""
+		}
+		// Walk up from bootmain dir to find the napcat logs directory
+		// Structure: <install>/versions/<ver>/resources/app/napcat/logs
+		logsDir := ""
+		filepath.WalkDir(napcatDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || logsDir != "" {
+				return nil
+			}
+			if d.IsDir() && strings.EqualFold(d.Name(), "logs") {
+				// Verify it looks like a napcat logs dir (has .log files)
+				entries, _ := os.ReadDir(path)
+				for _, e := range entries {
+					if strings.HasSuffix(strings.ToLower(e.Name()), ".log") {
+						logsDir = path
+						return filepath.SkipAll
 					}
+				}
+			}
+			return nil
+		})
+		// Also check parent dirs up 6 levels from napcatDir
+		if logsDir == "" {
+			dir := napcatDir
+			for i := 0; i < 8; i++ {
+				candidate := filepath.Join(dir, "logs")
+				if entries, err := os.ReadDir(candidate); err == nil {
+					for _, e := range entries {
+						if strings.HasSuffix(strings.ToLower(e.Name()), ".log") {
+							logsDir = candidate
+							break
+						}
+					}
+				}
+				if logsDir != "" {
+					break
+				}
+				parent := filepath.Dir(dir)
+				if parent == dir {
+					break
+				}
+				dir = parent
+			}
+		}
+		if logsDir != "" {
+			if tok := tokenFromNapCatLogs(logsDir); tok != "" {
+				return tok
+			}
+		}
+		// Fallback: try webui.json in bootmain config
+		data, err := os.ReadFile(filepath.Join(napcatDir, "config", "webui.json"))
+		if err == nil {
+			var webui map[string]interface{}
+			if json.Unmarshal(data, &webui) == nil {
+				if t, ok := webui["token"].(string); ok && t != "" {
+					return t
 				}
 			}
 		}
@@ -237,6 +289,40 @@ func readNapCatWebuiToken(cfg *config.Config) string {
 				if t, ok := webui["token"].(string); ok && t != "" {
 					return t
 				}
+			}
+		}
+	}
+	return ""
+}
+
+// tokenFromNapCatLogs finds the most recent NapCat log file and extracts the WebUI token.
+func tokenFromNapCatLogs(logsDir string) string {
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return ""
+	}
+	// Find the newest .log file
+	var newest os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ".log") {
+			if newest == nil || e.Name() > newest.Name() {
+				newest = e
+			}
+		}
+	}
+	if newest == nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(logsDir, newest.Name()))
+	if err != nil {
+		return ""
+	}
+	// Look for: [WebUi] WebUi Token: <token>
+	for _, line := range strings.Split(string(data), "\n") {
+		if idx := strings.Index(line, "[WebUi] WebUi Token: "); idx >= 0 {
+			tok := strings.TrimSpace(line[idx+len("[WebUi] WebUi Token: "):])
+			if tok != "" {
+				return tok
 			}
 		}
 	}
@@ -261,17 +347,19 @@ func napcatLoginWithToken(token string) string {
 }
 
 func napcatAuth(cfg *config.Config) string {
-	if napcatCredential != "" {
-		return napcatCredential
-	}
-
-	// 1. Try the actual token from NapCat's webui.json (ground truth)
+	// 1. Try the actual token from NapCat's log (NapCat 4.x generates random token each startup)
 	containerToken := readNapCatWebuiToken(cfg)
 	if containerToken != "" {
 		if cred := napcatLoginWithToken(containerToken); cred != "" {
 			napcatCredential = cred
 			return napcatCredential
 		}
+		// Token changed (NapCat restarted) — clear stale credential
+		napcatCredential = ""
+	}
+
+	if napcatCredential != "" {
+		return napcatCredential
 	}
 
 	// 2. Fallback: admin-config or default token (may differ from container)
@@ -348,7 +436,7 @@ func NapcatLoginStatus(cfg *config.Config) gin.HandlerFunc {
 
 func NapcatGetQRCode(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Retry up to 5 times (total ~10s) to wait for NapCat to become ready
+		// Retry up to 5 times (~10s) waiting for NapCat to become ready
 		var r map[string]interface{}
 		var err error
 		for i := 0; i < 5; i++ {
@@ -356,25 +444,77 @@ func NapcatGetQRCode(cfg *config.Config) gin.HandlerFunc {
 			if err == nil {
 				break
 			}
-			// NapCat not ready yet, wait and retry
 			time.Sleep(2 * time.Second)
-			napcatCredential = "" // clear stale credential
+			napcatCredential = ""
 		}
+
+		// If API failed, try CheckLoginStatus which also returns qrcodeurl
+		if err != nil || r == nil {
+			if r2, err2 := napcatApiCall(cfg, "POST", "/api/QQLogin/CheckLoginStatus", nil); err2 == nil {
+				if data2, ok := r2["data"].(map[string]interface{}); ok {
+					if u, ok := data2["qrcodeurl"].(string); ok && u != "" {
+						r = map[string]interface{}{"data": map[string]interface{}{"qrcode": u}}
+						err = nil
+					}
+				}
+			}
+		}
+
 		if err != nil {
+			// Last resort: serve the cached qrcode.png NapCat wrote to disk
+			if pngData := readNapCatQRCodePNG(cfg); len(pngData) > 0 {
+				c.JSON(200, gin.H{
+					"ok":   true,
+					"code": 0,
+					"data": gin.H{"qrcode": "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngData)},
+				})
+				return
+			}
 			c.JSON(200, gin.H{"ok": false, "error": err.Error()})
 			return
 		}
+
 		r["ok"] = true
 		// NapCat returns a URL in data.qrcode — convert to base64 QR image
 		if data, ok := r["data"].(map[string]interface{}); ok {
 			if qrURL, ok := data["qrcode"].(string); ok && qrURL != "" && !strings.HasPrefix(qrURL, "data:") {
-				if png, err := qrcode.Encode(qrURL, qrcode.Medium, 256); err == nil {
+				if png, encErr := qrcode.Encode(qrURL, qrcode.Medium, 256); encErr == nil {
 					data["qrcode"] = "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
 				}
 			}
 		}
 		c.JSON(200, r)
 	}
+}
+
+// readNapCatQRCodePNG reads the qrcode.png that NapCat saves to its cache directory.
+func readNapCatQRCodePNG(cfg *config.Config) []byte {
+	napcatDir := getNapCatShellDir(cfg)
+	if napcatDir == "" {
+		return nil
+	}
+	// Walk to find cache/qrcode.png
+	var pngPath string
+	filepath.WalkDir(napcatDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || pngPath != "" {
+			return nil
+		}
+		if !d.IsDir() && strings.EqualFold(d.Name(), "qrcode.png") {
+			pngPath = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if pngPath == "" {
+		return nil
+	}
+	// Only use if written within last 3 minutes (QR codes expire)
+	info, err := os.Stat(pngPath)
+	if err != nil || time.Since(info.ModTime()) > 3*time.Minute {
+		return nil
+	}
+	data, _ := os.ReadFile(pngPath)
+	return data
 }
 
 func NapcatRefreshQRCode(cfg *config.Config) gin.HandlerFunc {
@@ -507,21 +647,14 @@ func restartNapCatProcess(cfg *config.Config) {
 		exec.Command("taskkill", "/F", "/IM", "NapCatWinBootMain.exe").Run()
 		exec.Command("taskkill", "/F", "/IM", "napcat.exe").Run()
 		exec.Command("taskkill", "/F", "/IM", "QQ.exe").Run()
-		// Restart: find and launch napcat.bat
+		// Restart: launch NapCatWinBootMain.exe in the interactive user session via schtasks.
+		// ClawPanel runs as SYSTEM (session 0); direct exec cannot create GUI processes in
+		// the user's desktop session (session 1). schtasks runs as the interactive user.
 		napcatDir := getNapCatShellDir(cfg)
 		if napcatDir != "" {
-			batPath := filepath.Join(napcatDir, "napcat.bat")
-			if _, err := os.Stat(batPath); err == nil {
-				cmd := exec.Command("cmd", "/C", "start", "/B", batPath)
-				cmd.Dir = napcatDir
-				cmd.Start()
-				return
-			}
 			exePath := filepath.Join(napcatDir, "NapCatWinBootMain.exe")
 			if _, err := os.Stat(exePath); err == nil {
-				cmd := exec.Command(exePath)
-				cmd.Dir = napcatDir
-				cmd.Start()
+				launchInUserSession(exePath, napcatDir)
 			}
 		}
 	} else {
@@ -611,6 +744,116 @@ func ClawHubSync(cfg *config.Config) gin.HandlerFunc {
 		}
 		c.JSON(200, gin.H{"ok": true, "skills": []interface{}{}, "source": "empty"})
 	}
+}
+
+// launchInUserSession launches an executable in the interactive user session via schtasks.
+// Required because ClawPanel runs as SYSTEM (session 0) and cannot directly spawn GUI
+// processes in the user's desktop session (session 1).
+// getInteractiveUser returns the username of the currently logged-in interactive user.
+// WMIC outputs UTF-16LE; we decode it properly to handle non-ASCII usernames.
+func getInteractiveUser() string {
+	out, err := exec.Command("wmic", "computersystem", "get", "UserName", "/VALUE").Output()
+	if err == nil {
+		text := decodeUTF16LEHandler(out)
+		for _, line := range strings.Split(text, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(strings.ToLower(line), "username=") {
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+					return strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+	// Fallback: qwinsta.exe shows active console sessions
+	out2, err := exec.Command(`C:\Windows\System32\qwinsta.exe`).Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out2), "\n") {
+			if strings.Contains(line, "Active") || strings.Contains(line, "活动") {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					u := strings.TrimPrefix(fields[0], ">")
+					if strings.HasPrefix(strings.ToLower(u), "console") || strings.HasPrefix(strings.ToLower(u), "rdp") {
+						u = fields[1]
+					}
+					if u != "" && !strings.EqualFold(u, "services") {
+						return u
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// decodeUTF16LEHandler decodes UTF-16LE bytes (WMIC output) to UTF-8 string.
+func decodeUTF16LEHandler(b []byte) string {
+	if len(b) >= 2 && b[0] == 0xFF && b[1] == 0xFE {
+		b = b[2:]
+	}
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = uint16(b[2*i]) | uint16(b[2*i+1])<<8
+	}
+	var sb strings.Builder
+	for i := 0; i < len(u16); {
+		c := rune(u16[i])
+		i++
+		if c >= 0xD800 && c <= 0xDBFF && i < len(u16) {
+			low := rune(u16[i])
+			if low >= 0xDC00 && low <= 0xDFFF {
+				c = 0x10000 + (c-0xD800)*0x400 + (low - 0xDC00)
+				i++
+			}
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
+}
+
+// launchInUserSession launches an executable in the interactive user session.
+// Uses schtasks /RU <interactive_user> so the process runs in the user's desktop
+// session (session 1) even when called from a SYSTEM service (session 0).
+func launchInUserSession(exePath, workDir string) {
+	username := getInteractiveUser()
+	if username != "" {
+		psContent := fmt.Sprintf(
+			"Set-Location '%s'\nStart-Process -FilePath '%s' -WorkingDirectory '%s' -WindowStyle Hidden\n",
+			workDir, exePath, workDir)
+		psFile := filepath.Join(os.TempDir(), "napcat_launch_h.ps1")
+		if err := os.WriteFile(psFile, []byte(psContent), 0644); err == nil {
+			taskName := "ClawPanelStartNapCatH"
+			tr := fmt.Sprintf(
+				"powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File \"%s\"",
+				psFile)
+			exec.Command("schtasks", "/Delete", "/TN", taskName, "/F").Run()
+			err := exec.Command("schtasks", "/Create", "/F",
+				"/TN", taskName,
+				"/SC", "ONCE",
+				"/ST", "00:00",
+				"/RU", username,
+				"/TR", tr,
+				"/RL", "HIGHEST",
+			).Run()
+			if err == nil {
+				if err = exec.Command("schtasks", "/Run", "/TN", taskName).Run(); err == nil {
+					go func() {
+						time.Sleep(15 * time.Second)
+						exec.Command("schtasks", "/Delete", "/TN", taskName, "/F").Run()
+						os.Remove(psFile)
+					}()
+					return
+				}
+			}
+		}
+	}
+	// Fallback: direct exec
+	cmd := exec.Command(exePath)
+	cmd.Dir = workDir
+	cmd.Start()
 }
 
 // helper to read openclaw.json

--- a/internal/handler/events.go
+++ b/internal/handler/events.go
@@ -2,11 +2,13 @@ package handler
 
 import (
 	"database/sql"
+	"encoding/json"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zhaoxinyi02/ClawPanel/internal/model"
+	ws "github.com/zhaoxinyi02/ClawPanel/internal/websocket"
 )
 
 // GetEvents 获取事件日志
@@ -45,7 +47,7 @@ func ClearEvents(db *sql.DB) gin.HandlerFunc {
 }
 
 // PostEvent 外部服务提交事件（无需认证）
-func PostEvent(db *sql.DB) gin.HandlerFunc {
+func PostEvent(db *sql.DB, hub *ws.Hub) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req struct {
 			Source  string `json:"source"`
@@ -65,15 +67,34 @@ func PostEvent(db *sql.DB) gin.HandlerFunc {
 			req.Type = "openclaw.action"
 		}
 
-		id, err := model.AddEvent(db, &model.Event{
+		e := &model.Event{
 			Source:  req.Source,
 			Type:    req.Type,
 			Summary: req.Summary,
 			Detail:  req.Detail,
-		})
+		}
+
+		id, err := model.AddEvent(db, e)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": err.Error()})
 			return
+		}
+
+		if hub != nil {
+			entry := map[string]interface{}{
+				"id":      id,
+				"time":    e.Time,
+				"source":  e.Source,
+				"type":    e.Type,
+				"summary": e.Summary,
+				"detail":  e.Detail,
+			}
+			if payload, err := json.Marshal(map[string]interface{}{
+				"type": "log-entry",
+				"data": entry,
+			}); err == nil {
+				hub.Broadcast(payload)
+			}
 		}
 
 		c.JSON(http.StatusOK, gin.H{"ok": true, "id": id})

--- a/internal/monitor/launch_windows.go
+++ b/internal/monitor/launch_windows.go
@@ -1,0 +1,559 @@
+//go:build windows
+
+package monitor
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modKernel32             = windows.NewLazySystemDLL("kernel32.dll")
+	modAdvapi32             = windows.NewLazySystemDLL("advapi32.dll")
+	modWtsapi32             = windows.NewLazySystemDLL("wtsapi32.dll")
+	procOpenProcessToken    = modAdvapi32.NewProc("OpenProcessToken")
+	procDuplicateTokenEx    = modAdvapi32.NewProc("DuplicateTokenEx")
+	procSetTokenInformation = modAdvapi32.NewProc("SetTokenInformation")
+	procCreateProcessAsUserW = modAdvapi32.NewProc("CreateProcessAsUserW")
+	procWTSQuerySessionInformationW = modWtsapi32.NewProc("WTSQuerySessionInformationW")
+	procWTSFreeMemory       = modWtsapi32.NewProc("WTSFreeMemory")
+	modUserenv              = windows.NewLazySystemDLL("userenv.dll")
+	procCreateEnvironmentBlock  = modUserenv.NewProc("CreateEnvironmentBlock")
+	procDestroyEnvironmentBlock = modUserenv.NewProc("DestroyEnvironmentBlock")
+)
+
+const (
+	TOKEN_DUPLICATE          = 0x0002
+	TOKEN_QUERY              = 0x0008
+	TOKEN_ASSIGN_PRIMARY     = 0x0001
+	TOKEN_ADJUST_PRIVILEGES  = 0x0020
+	TOKEN_ADJUST_SESSIONID   = 0x0100
+	TOKEN_ADJUST_DEFAULT     = 0x0080
+	SecurityImpersonation    = 2
+	TokenPrimary             = 1
+	TokenSessionId           = 12
+	CREATE_UNICODE_ENVIRONMENT = 0x00000400
+	NORMAL_PRIORITY_CLASS    = 0x00000020
+	CREATE_NEW_CONSOLE       = 0x00000010
+	CREATE_NO_WINDOW         = 0x08000000
+)
+
+type STARTUPINFOW struct {
+	Cb            uint32
+	LpReserved    *uint16
+	LpDesktop     *uint16
+	LpTitle       *uint16
+	DwX           uint32
+	DwY           uint32
+	DwXSize       uint32
+	DwYSize       uint32
+	DwXCountChars uint32
+	DwYCountChars uint32
+	DwFillAttribute uint32
+	DwFlags       uint32
+	WShowWindow   uint16
+	CbReserved2   uint16
+	LpReserved2   *byte
+	HStdInput     windows.Handle
+	HStdOutput    windows.Handle
+	HStdError     windows.Handle
+}
+
+type PROCESS_INFORMATION struct {
+	HProcess    windows.Handle
+	HThread     windows.Handle
+	DwProcessId uint32
+	DwThreadId  uint32
+}
+
+// launchAsInteractiveUser launches a process in the interactive user's session (session 1)
+// by stealing the token from explorer.exe (which runs in session 1).
+// cmdLine is the full quoted command line. extraEnv is appended to the user environment.
+func launchAsInteractiveUser(cmdLine, workDir string, extraEnv []string) error {
+	// Find explorer.exe in session 1
+	explorerPID, err := findExplorerPID()
+	if err != nil {
+		return fmt.Errorf("find explorer.exe: %w", err)
+	}
+	log.Printf("[NapCat] Found explorer.exe PID=%d, stealing token for session-1 launch", explorerPID)
+
+	// Open the explorer process
+	hProcess, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_INFORMATION,
+		false,
+		explorerPID,
+	)
+	if err != nil {
+		return fmt.Errorf("OpenProcess explorer: %w", err)
+	}
+	defer windows.CloseHandle(hProcess)
+
+	// Open the process token
+	var hToken windows.Token
+	r, _, e := procOpenProcessToken.Call(
+		uintptr(hProcess),
+		TOKEN_DUPLICATE|TOKEN_QUERY,
+		uintptr(unsafe.Pointer(&hToken)),
+	)
+	if r == 0 {
+		return fmt.Errorf("OpenProcessToken: %w", e)
+	}
+	defer hToken.Close()
+
+	// Duplicate the token as a primary token
+	var hDupToken windows.Token
+	r, _, e = procDuplicateTokenEx.Call(
+		uintptr(hToken),
+		TOKEN_ASSIGN_PRIMARY|TOKEN_DUPLICATE|TOKEN_QUERY|TOKEN_ADJUST_PRIVILEGES|TOKEN_ADJUST_SESSIONID|TOKEN_ADJUST_DEFAULT,
+		0,
+		SecurityImpersonation,
+		TokenPrimary,
+		uintptr(unsafe.Pointer(&hDupToken)),
+	)
+	if r == 0 {
+		return fmt.Errorf("DuplicateTokenEx: %w", e)
+	}
+	defer hDupToken.Close()
+
+	// Force the duplicated token into session 1 so the process actually runs there.
+	sessionID := uint32(1)
+	procSetTokenInformation.Call(
+		uintptr(hDupToken),
+		TokenSessionId,
+		uintptr(unsafe.Pointer(&sessionID)),
+		uintptr(unsafe.Sizeof(sessionID)),
+	)
+
+	// Create environment block for the user token.
+	var rawEnvBlock uintptr
+	procCreateEnvironmentBlock.Call(
+		uintptr(unsafe.Pointer(&rawEnvBlock)),
+		uintptr(hDupToken),
+		0,
+	)
+
+	// Build the final env block (user env merged with extraEnv overrides).
+	var finalEnvBlock uintptr
+	if len(extraEnv) > 0 && rawEnvBlock != 0 {
+		merged := mergeEnvBlock(rawEnvBlock, extraEnv)
+		procDestroyEnvironmentBlock.Call(rawEnvBlock)
+		finalEnvBlock = uintptr(unsafe.Pointer(&merged[0]))
+	} else {
+		finalEnvBlock = rawEnvBlock
+		if rawEnvBlock != 0 {
+			defer procDestroyEnvironmentBlock.Call(rawEnvBlock)
+		}
+	}
+
+	// Build command line UTF16 pointer
+	cmdLinePtr, err := windows.UTF16PtrFromString(cmdLine)
+	if err != nil {
+		return fmt.Errorf("UTF16PtrFromString cmdLine: %w", err)
+	}
+	wd, err := windows.UTF16PtrFromString(workDir)
+	if err != nil {
+		return fmt.Errorf("UTF16PtrFromString workDir: %w", err)
+	}
+
+	si := STARTUPINFOW{
+		Cb: uint32(unsafe.Sizeof(STARTUPINFOW{})),
+	}
+	// Set desktop to winsta0\default (interactive desktop)
+	desktop, _ := windows.UTF16PtrFromString(`winsta0\default`)
+	si.LpDesktop = desktop
+
+	var pi PROCESS_INFORMATION
+
+	// Do NOT use CREATE_NO_WINDOW — NapCat needs desktop access for DLL injection into QQ.
+	creationFlags := uint32(CREATE_UNICODE_ENVIRONMENT | NORMAL_PRIORITY_CLASS)
+
+	r, _, e = procCreateProcessAsUserW.Call(
+		uintptr(hDupToken),
+		0,
+		uintptr(unsafe.Pointer(cmdLinePtr)),
+		0,
+		0,
+		0,
+		uintptr(creationFlags),
+		finalEnvBlock,
+		uintptr(unsafe.Pointer(wd)),
+		uintptr(unsafe.Pointer(&si)),
+		uintptr(unsafe.Pointer(&pi)),
+	)
+	if r == 0 {
+		return fmt.Errorf("CreateProcessAsUserW: %w", e)
+	}
+
+	windows.CloseHandle(pi.HProcess)
+	windows.CloseHandle(pi.HThread)
+	log.Printf("[NapCat] Launched in session 1 via CreateProcessAsUser (PID=%d): %s", pi.DwProcessId, cmdLine)
+	return nil
+}
+
+// findExplorerPID returns the PID of explorer.exe running in session 1.
+func findExplorerPID() (uint32, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var pe windows.ProcessEntry32
+	pe.Size = uint32(unsafe.Sizeof(pe))
+	if err := windows.Process32First(snapshot, &pe); err != nil {
+		return 0, err
+	}
+	for {
+		name := windows.UTF16ToString(pe.ExeFile[:])
+		if name == "explorer.exe" {
+			// Verify it's in session 1
+			h, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pe.ProcessID)
+			if err == nil {
+				var sessionID uint32
+				if err2 := windows.ProcessIdToSessionId(pe.ProcessID, &sessionID); err2 == nil && sessionID == 1 {
+					windows.CloseHandle(h)
+					return pe.ProcessID, nil
+				}
+				windows.CloseHandle(h)
+			}
+		}
+		if err := windows.Process32Next(snapshot, &pe); err != nil {
+			break
+		}
+	}
+	return 0, fmt.Errorf("explorer.exe not found in session 1")
+}
+
+// mergeEnvBlock parses the Windows UTF-16 environment block at rawBlock,
+// overrides/adds the key=value pairs from extraEnv, and returns a new
+// UTF-16 double-null-terminated env block suitable for CreateProcessAsUserW.
+func mergeEnvBlock(rawBlock uintptr, extraEnv []string) []uint16 {
+	// Parse existing env block (null-separated UTF-16 pairs, double-null terminated)
+	env := map[string]string{}
+	ptr := rawBlock
+	for {
+		// Read null-terminated UTF-16 string
+		var chars []uint16
+		for {
+			w := *(*uint16)(unsafe.Pointer(ptr))
+			ptr += 2
+			if w == 0 {
+				break
+			}
+			chars = append(chars, w)
+		}
+		if len(chars) == 0 {
+			break // double-null: end of block
+		}
+		kv := windows.UTF16ToString(chars)
+		if idx := strings.Index(kv, "="); idx > 0 {
+			env[strings.ToUpper(kv[:idx])] = kv[idx+1:]
+		}
+	}
+	// Override with extra vars
+	for _, kv := range extraEnv {
+		if idx := strings.Index(kv, "="); idx > 0 {
+			env[strings.ToUpper(kv[:idx])] = kv[idx+1:]
+		}
+	}
+	// Rebuild block
+	var out []uint16
+	for k, v := range env {
+		entry := k + "=" + v
+		u16, _ := windows.UTF16FromString(entry)
+		out = append(out, u16...) // includes null terminator from UTF16FromString
+	}
+	out = append(out, 0) // double-null terminator
+	return out
+}
+
+// launchNapCatInUserSession launches NapCat in the interactive user session.
+// Strategy: write a PowerShell launcher script then run it via schtasks /RU <user>.
+// We get the username via WTSQuerySessionInformationW (proper Unicode, no WMIC encoding issues).
+// Fallback: CreateProcessAsUser with explorer.exe token.
+func launchNapCatInUserSession(exePath, workDir string) error {
+	batPath := findNapCatLauncherBat(workDir)
+	if batPath == "" {
+		return fmt.Errorf("launcher-user.bat not found in %s", workDir)
+	}
+	batDir := filepath.Dir(batPath)
+
+	// Write a PS1 wrapper that runs the bat without pausing
+	psContent := fmt.Sprintf(
+		"$p = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c \"%s\"' -WorkingDirectory '%s' -WindowStyle Hidden -PassThru; exit 0\r\n",
+		batPath, batDir)
+	psFile := filepath.Join(os.TempDir(), "napcat_launch.ps1")
+	if err := os.WriteFile(psFile, []byte(psContent), 0644); err != nil {
+		return fmt.Errorf("write ps1: %w", err)
+	}
+
+	taskCmd := fmt.Sprintf(`powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%s"`, psFile)
+
+	// Try schtasks with WTS username first (proper Unicode)
+	username := getSession1Username()
+	taskName := "ClawPanelStartNapCat"
+	exec.Command("schtasks", "/Delete", "/TN", taskName, "/F").Run()
+
+	var createErr error
+	if username != "" {
+		log.Printf("[NapCat] schtasks /RU %s", username)
+		createErr = exec.Command("schtasks", "/Create", "/F",
+			"/TN", taskName, "/SC", "ONCE", "/ST", "00:00",
+			"/RU", username, "/TR", taskCmd, "/RL", "HIGHEST",
+		).Run()
+	}
+	if username == "" || createErr != nil {
+		// Fallback: omit /RU (runs as SYSTEM but still triggers via schtasks)
+		log.Printf("[NapCat] schtasks without /RU (username=%q, err=%v)", username, createErr)
+		createErr = exec.Command("schtasks", "/Create", "/F",
+			"/TN", taskName, "/SC", "ONCE", "/ST", "00:00",
+			"/TR", taskCmd, "/RL", "HIGHEST",
+		).Run()
+	}
+	if createErr != nil {
+		// Last resort: CreateProcessAsUser
+		log.Printf("[NapCat] schtasks create failed (%v), using CreateProcessAsUser", createErr)
+		cmdLine, extraEnv, err := buildNapCatCommandLine(exePath, workDir)
+		if err != nil {
+			return fmt.Errorf("buildNapCatCommandLine: %w", err)
+		}
+		return launchAsInteractiveUser(cmdLine, workDir, extraEnv)
+	}
+
+	runErr := exec.Command("schtasks", "/Run", "/TN", taskName).Run()
+	go func() {
+		time.Sleep(20 * time.Second)
+		exec.Command("schtasks", "/Delete", "/TN", taskName, "/F").Run()
+		os.Remove(psFile)
+	}()
+	if runErr != nil {
+		return fmt.Errorf("schtasks run: %w", runErr)
+	}
+	log.Printf("[NapCat] schtasks launched NapCat via %s", batPath)
+	return nil
+}
+
+// getSession1Username returns the domain\username of the user logged into session 1
+// using WTSQuerySessionInformationW which returns proper Unicode strings.
+func getSession1Username() string {
+	const WTSUserName   = 5
+	const WTSDomainName = 7
+	const WTS_CURRENT_SERVER_HANDLE = 0
+
+	getDomainUser := func(sessionID uint32, infoClass uintptr) string {
+		var pBuf uintptr
+		var bytes uint32
+		r, _, _ := procWTSQuerySessionInformationW.Call(
+			WTS_CURRENT_SERVER_HANDLE,
+			uintptr(sessionID),
+			infoClass,
+			uintptr(unsafe.Pointer(&pBuf)),
+			uintptr(unsafe.Pointer(&bytes)),
+		)
+		if r == 0 || pBuf == 0 {
+			return ""
+		}
+		defer procWTSFreeMemory.Call(pBuf)
+		// pBuf points to a null-terminated UTF-16 string
+		nChars := bytes / 2
+		if nChars == 0 {
+			return ""
+		}
+		u16 := make([]uint16, nChars)
+		for i := uintptr(0); i < uintptr(nChars); i++ {
+			u16[i] = *(*uint16)(unsafe.Pointer(pBuf + i*2))
+		}
+		return windows.UTF16ToString(u16)
+	}
+
+	domain := getDomainUser(1, WTSDomainName)
+	user   := getDomainUser(1, WTSUserName)
+	if user == "" {
+		return ""
+	}
+	if domain != "" && !strings.EqualFold(domain, ".") {
+		return domain + `\` + user
+	}
+	return user
+}
+
+// findNapCatLauncherBat finds launcher-user.bat in the NapCat shell tree.
+func findNapCatLauncherBat(shellDir string) string {
+	// Check inner dir first (versions/.../napcat/)
+	innerDir := findNapCatInnerDir(shellDir)
+	if innerDir != "" {
+		p := filepath.Join(innerDir, "launcher-user.bat")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+		p = filepath.Join(innerDir, "launcher.bat")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	// Check top-level shell dir
+	for _, name := range []string{"launcher-user.bat", "napcat.bat"} {
+		p := filepath.Join(shellDir, name)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// buildNapCatCommandLine builds the full NapCatWinBootMain.exe command line with
+// the QQ path argument and env vars, mimicking launcher-user.bat.
+// napcatShellDir is the top-level NapCat.Shell dir. The inner resource dir
+// (containing napcat.mjs, qqnt.json, and the actual NapCatWinBootMain.exe) is found by walking.
+func buildNapCatCommandLine(_, napcatShellDir string) (cmdLine string, extraEnv []string, err error) {
+	// Find QQ.exe path from registry (same as launcher.bat)
+	qqPath := findQQExePath()
+	if qqPath == "" {
+		err = fmt.Errorf("QQ.exe not found in registry or common paths")
+		return
+	}
+	log.Printf("[NapCat] Found QQ.exe at: %s", qqPath)
+
+	// Find the inner napcat resource dir (where napcat.mjs lives)
+	innerDir := findNapCatInnerDir(napcatShellDir)
+	if innerDir == "" {
+		innerDir = napcatShellDir // Fallback
+	}
+	log.Printf("[NapCat] Inner napcat dir: %s", innerDir)
+
+	// Use the inner NapCatWinBootMain.exe (the actual injector, not the top-level stub)
+	innerBootMain := filepath.Join(innerDir, "NapCatWinBootMain.exe")
+	if _, e := os.Stat(innerBootMain); e != nil {
+		// Fall back to shell dir
+		innerBootMain = filepath.Join(napcatShellDir, "NapCatWinBootMain.exe")
+	}
+	log.Printf("[NapCat] Using boot main: %s", innerBootMain)
+
+	// NAPCAT_MAIN_PATH uses forward slashes (as in the bat)
+	napcatMjs := filepath.Join(innerDir, "napcat.mjs")
+	napcatMjsFwd := strings.ReplaceAll(napcatMjs, `\`, `/`)
+
+	// Write loadNapCat.js into the inner dir (same as the bat does with echo)
+	loadPath := filepath.Join(innerDir, "loadNapCat.js")
+	loadContent := fmt.Sprintf(`(async () => {await import("file:///%s")})()`, napcatMjsFwd)
+	if werr := os.WriteFile(loadPath, []byte(loadContent), 0644); werr != nil {
+		log.Printf("[NapCat] warning: could not write loadNapCat.js: %v", werr)
+	}
+
+	// Use inner NapCatWinBootHook.dll (larger, 20KB version in inner dir)
+	injectDll := filepath.Join(innerDir, "NapCatWinBootHook.dll")
+	if _, e := os.Stat(injectDll); e != nil {
+		injectDll = filepath.Join(napcatShellDir, "NapCatWinBootHook.dll")
+	}
+
+	extraEnv = []string{
+		"NAPCAT_PATCH_PACKAGE=" + filepath.Join(innerDir, "qqnt.json"),
+		"NAPCAT_LOAD_PATH=" + loadPath,
+		"NAPCAT_INJECT_PATH=" + injectDll,
+		"NAPCAT_LAUNCHER_PATH=" + innerBootMain,
+		"NAPCAT_MAIN_PATH=" + napcatMjs,
+	}
+
+	// Command line: "NapCatWinBootMain.exe" "D:\QQ\QQ.exe" "NapCatWinBootHook.dll"
+	cmdLine = fmt.Sprintf(`"%s" "%s" "%s"`, innerBootMain, qqPath, injectDll)
+	return
+}
+
+// findNapCatInnerDir finds the inner napcat resource directory (where napcat.mjs lives)
+// by walking the NapCat Shell directory tree.
+func findNapCatInnerDir(shellDir string) string {
+	var found string
+	filepath.WalkDir(shellDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || found != "" {
+			return nil
+		}
+		if !d.IsDir() && strings.EqualFold(d.Name(), "napcat.mjs") {
+			found = filepath.Dir(path)
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// findQQExePath finds the QQ.exe path via registry, then common locations.
+func findQQExePath() string {
+	// Same registry key as launcher.bat
+	out, err := exec.Command("reg", "query",
+		`HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\QQ`,
+		"/v", "UninstallString").Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(strings.ToLower(line), "uninstallstring") {
+				parts := strings.Fields(line)
+				if len(parts) >= 3 {
+					uninstStr := strings.Trim(parts[len(parts)-1], `"`)
+					qqDir := filepath.Dir(uninstStr)
+					qqExe := filepath.Join(qqDir, "QQ.exe")
+					if _, e := os.Stat(qqExe); e == nil {
+						return qqExe
+					}
+				}
+			}
+		}
+	}
+	// Fallback: common locations
+	for _, p := range []string{`D:\QQ\QQ.exe`, `C:\Program Files\Tencent\QQ\QQ.exe`, `C:\QQ\QQ.exe`} {
+		if _, e := os.Stat(p); e == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// launchNapCatViaBat launches NapCat via the launcher-user.bat as a fallback.
+func launchNapCatViaBat(napcatDir string) error {
+	batPath := filepath.Join(napcatDir, "launcher-user.bat")
+	if _, err := os.Stat(batPath); err != nil {
+		// Try the top-level napcat.bat
+		batPath = filepath.Join(filepath.Dir(napcatDir), "napcat.bat")
+		if _, err2 := os.Stat(batPath); err2 != nil {
+			return fmt.Errorf("no launcher bat found")
+		}
+	}
+	cmdLine := fmt.Sprintf(`cmd.exe /c "%s"`, batPath)
+	return launchAsInteractiveUser(cmdLine, napcatDir, nil)
+}
+
+// launchNapCatViaSchtasks is the schtasks fallback for launchNapCatInUserSession.
+func launchNapCatViaSchtasks(cmdLine, workDir string) error {
+	psContent := fmt.Sprintf("Set-Location '%s'\n%s\n", workDir, cmdLine)
+	psFile := filepath.Join(os.TempDir(), "napcat_launch.ps1")
+	_ = os.WriteFile(psFile, []byte(psContent), 0644)
+
+	username := getInteractiveUsername()
+	taskName := "ClawPanelStartNapCat"
+	tr := fmt.Sprintf(`powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%s"`, psFile)
+	exec.Command("schtasks", "/Delete", "/TN", taskName, "/F").Run()
+	var createArgs []string
+	createArgs = []string{"/Create", "/F", "/TN", taskName, "/SC", "ONCE", "/ST", "00:00", "/TR", tr, "/RL", "HIGHEST"}
+	if username != "" {
+		createArgs = append(createArgs, "/RU", username)
+	}
+	err := exec.Command("schtasks", createArgs...).Run()
+	if err == nil {
+		if err = exec.Command("schtasks", "/Run", "/TN", taskName).Run(); err == nil {
+			go func() {
+				time.Sleep(15 * time.Second)
+				exec.Command("schtasks", "/Delete", "/TN", taskName, "/F").Run()
+				os.Remove(psFile)
+			}()
+			return nil
+		}
+	}
+	return fmt.Errorf("schtasks failed: %w", err)
+}

--- a/internal/monitor/napcat.go
+++ b/internal/monitor/napcat.go
@@ -56,11 +56,11 @@ type NapCatMonitor struct {
 	maxLogs        int
 	stopCh         chan struct{}
 	running        bool
-	paused         bool // true when QQ channel is disabled — skip checks
+	paused         bool          // true when QQ channel is disabled — skip checks
 	checkInterval  time.Duration
-	reconnecting   bool // true while a reconnect is in progress
-	offlineCount   int  // consecutive offline checks before triggering reconnect
-	loginFailCount int  // consecutive login check failures before declaring login_expired
+	reconnecting   bool          // true while a reconnect is in progress
+	offlineCount   int           // consecutive offline checks before triggering reconnect
+	loginFailCount int           // consecutive login check failures before declaring login_expired
 }
 
 // NewNapCatMonitor creates a new NapCat monitor
@@ -228,6 +228,7 @@ func (m *NapCatMonitor) checkAndUpdate() {
 
 	// Determine overall status
 	if !containerRunning {
+		m.offlineCount++
 		m.status.Status = "stopped"
 		m.loginFailCount = 0
 	} else if qqLoggedIn {
@@ -251,9 +252,17 @@ func (m *NapCatMonitor) checkAndUpdate() {
 		}
 		m.offlineCount = 0
 	} else if containerRunning {
-		// Container running but services not responding yet (booting up)
+		// Container running but OneBot services (3001/3000) not responding.
+		// If port 6099 is up, NapCat WebUI is alive — it's just waiting for QR scan.
+		// Treat as login_expired (don't auto-restart — user needs to scan QR code).
+		webuiUp := isPortReachable(6099)
 		m.offlineCount++
-		if m.offlineCount <= 3 {
+		if webuiUp {
+			// NapCat is running and reachable — login needed, not a crash
+			m.status.Status = "login_expired"
+			m.loginFailCount++
+			m.offlineCount = 0 // reset so auto-reconnect doesn't fire
+		} else if m.offlineCount <= 3 {
 			// Give it a few checks to boot up before declaring offline
 			m.status.Status = prevStatus // keep previous status
 		} else {
@@ -270,6 +279,15 @@ func (m *NapCatMonitor) checkAndUpdate() {
 	maxReconnect := m.status.MaxReconnect
 	offlineCount := m.offlineCount
 	m.mu.Unlock()
+
+	// When NapCat is running but WS/HTTP not yet listening, ensure network config exists.
+	// This handles the case where QQ just logged in and config was empty.
+	if containerRunning && (!wsConnected || !httpAvailable) && isPortReachable(6099) {
+		napcatDir := findNapCatShellDir(m.cfg)
+		if napcatDir != "" {
+			go ensureNapCatNetworkConfig(napcatDir)
+		}
+	}
 
 	// Broadcast status change
 	if currentStatus != prevStatus {
@@ -294,10 +312,10 @@ func (m *NapCatMonitor) checkAndUpdate() {
 		}
 	}
 
-	// Auto-reconnect: only trigger for "offline" (services down), NOT for "login_expired"
-	// login_expired means container is fine but QQ session expired — restarting container won't help,
-	// the user needs to re-scan QR code.
-	if autoReconnect && currentStatus == "offline" && offlineCount >= 3 {
+	// Auto-reconnect: trigger for "offline" (services down) or "stopped" (process not running).
+	// NOT for "login_expired" — that means NapCat WebUI is up but QQ session expired;
+	// user needs to re-scan QR code.
+	if autoReconnect && (currentStatus == "offline" || currentStatus == "stopped") && offlineCount >= 3 {
 		if reconnectCount < maxReconnect {
 			m.mu.Lock()
 			m.status.Status = "reconnecting"
@@ -354,52 +372,37 @@ func (m *NapCatMonitor) doReconnect(reason string) error {
 		return err
 	}
 
-	// Wait for container to come back up
-	time.Sleep(10 * time.Second)
+	// Wait for NapCat to start — on Windows with schtasks there's a delay before the
+	// process actually launches. Poll port 6099 (WebUI) since 3001/3000 only come up
+	// after QQ login which requires a QR scan.
+	time.Sleep(8 * time.Second)
 
-	// Check if services are back
-	wsOK := false
-	for i := 0; i < 6; i++ {
-		if isPortReachable(3001) {
-			wsOK = true
+	webuiOK := false
+	for i := 0; i < 12; i++ {
+		if isPortReachable(6099) {
+			webuiOK = true
 			break
 		}
 		time.Sleep(5 * time.Second)
 	}
 
-	if wsOK {
+	if webuiOK {
 		rlog.Success = true
-		rlog.Detail = "容器重启成功，WebSocket 服务已恢复"
+		rlog.Detail = "NapCat 已重启，WebUI 已可用，等待 QQ 扫码登录"
 		m.addLog(rlog)
 
-		// Check login status
-		loggedIn, nickname, qqid := checkQQLoginStatus(m.cfg)
 		m.mu.Lock()
-		m.status.WSConnected = true
-		m.status.HTTPAvailable = isPortReachable(3000)
-		m.status.QQLoggedIn = loggedIn
-		m.status.QQNickname = nickname
-		m.status.QQID = qqid
-		if loggedIn {
-			m.status.Status = "online"
-			m.status.LastOnline = time.Now()
-			m.status.ReconnectCount = 0
-		} else {
-			m.status.Status = "login_expired"
-		}
+		m.status.ContainerRunning = true
+		m.status.Status = "login_expired"
 		m.mu.Unlock()
 		m.broadcastStatus()
 
-		if loggedIn {
-			m.sysLog.Log("system", "napcat.reconnected", fmt.Sprintf("NapCat 重连成功，QQ 已上线 (%s: %s)", qqid, nickname))
-		} else {
-			m.sysLog.Log("system", "napcat.reconnected_no_login", "NapCat 容器已重启，但 QQ 需要重新登录")
-		}
+		m.sysLog.Log("system", "napcat.reconnected_no_login", "NapCat 已重启，请扫码登录 QQ")
 		return nil
 	}
 
 	rlog.Success = false
-	rlog.Detail = "容器重启后 WebSocket 服务未恢复"
+	rlog.Detail = "NapCat 重启后 WebUI (port 6099) 未恢复"
 	m.addLog(rlog)
 
 	m.mu.Lock()
@@ -407,8 +410,8 @@ func (m *NapCatMonitor) doReconnect(reason string) error {
 	m.mu.Unlock()
 	m.broadcastStatus()
 
-	m.sysLog.Log("system", "napcat.reconnect_failed", "NapCat 重连后服务未恢复")
-	return fmt.Errorf("WebSocket 服务未恢复")
+	m.sysLog.Log("system", "napcat.reconnect_failed", "NapCat 重连后 WebUI 未恢复")
+	return fmt.Errorf("NapCat WebUI 未恢复")
 }
 
 func (m *NapCatMonitor) addLog(rlog ReconnectLog) {
@@ -446,19 +449,22 @@ func isContainerRunning(name string) bool {
 	return err == nil && strings.TrimSpace(string(out)) == "true"
 }
 
-// isNapCatProcessRunning checks if NapCat is running, platform-aware
+// isNapCatProcessRunning checks if NapCat is running in the interactive session (session 1).
+// On Windows we check for NapCatWinBootMain.exe AND that port 6099 is reachable,
+// because a zombie session-0 process with no port is not "running" for our purposes.
 func isNapCatProcessRunning() bool {
 	if runtime.GOOS == "windows" {
-		// Check for NapCat Shell process on Windows
 		out, err := exec.Command("tasklist", "/FI", "IMAGENAME eq NapCatWinBootMain.exe", "/NH").Output()
-		if err == nil && strings.Contains(string(out), "NapCatWinBootMain") {
-			return true
+		if err != nil || !strings.Contains(string(out), "NapCatWinBootMain") {
+			out2, err2 := exec.Command("tasklist", "/FI", "IMAGENAME eq napcat.exe", "/NH").Output()
+			if err2 != nil || !strings.Contains(string(out2), "napcat.exe") {
+				return false
+			}
 		}
-		out2, err := exec.Command("tasklist", "/FI", "IMAGENAME eq napcat.exe", "/NH").Output()
-		if err == nil && strings.Contains(string(out2), "napcat.exe") {
-			return true
-		}
-		return false
+		// Process exists — consider it running only if port 6099 is actually listening.
+		// A zombie NapCat (lost QQ pipe, no port) should be treated as stopped so
+		// the monitor can restart it.
+		return isPortReachable(6099)
 	}
 	return isContainerRunning("openclaw-qq")
 }
@@ -474,43 +480,187 @@ func StopNapCatPlatform() {
 	}
 }
 
-// restartNapCatPlatform restarts NapCat based on platform
+// restartNapCatPlatform restarts NapCat based on platform.
+// On Windows: only kills if port 6099 is already down (NapCat crashed), then relaunches
+// via schtasks in the interactive user session.
 func restartNapCatPlatform(cfg *config.Config) ([]byte, error) {
 	if runtime.GOOS == "windows" {
-		// Kill NapCat processes
-		exec.Command("taskkill", "/F", "/IM", "NapCatWinBootMain.exe").Run()
-		exec.Command("taskkill", "/F", "/IM", "napcat.exe").Run()
-		exec.Command("taskkill", "/F", "/IM", "QQ.exe").Run()
-		time.Sleep(2 * time.Second)
-		// Find and restart NapCat Shell
 		napcatDir := findNapCatShellDir(cfg)
 		if napcatDir == "" {
 			return []byte("NapCat Shell directory not found"), fmt.Errorf("NapCat Shell not installed")
 		}
-		batPath := filepath.Join(napcatDir, "napcat.bat")
-		if _, err := os.Stat(batPath); err == nil {
-			cmd := exec.Command("cmd", "/C", "start", "/B", batPath)
-			cmd.Dir = napcatDir
-			err := cmd.Start()
-			if err != nil {
-				return []byte(err.Error()), err
-			}
-			return []byte("NapCat Shell restarted"), nil
-		}
 		exePath := filepath.Join(napcatDir, "NapCatWinBootMain.exe")
-		if _, err := os.Stat(exePath); err == nil {
-			cmd := exec.Command(exePath)
-			cmd.Dir = napcatDir
-			err := cmd.Start()
-			if err != nil {
-				return []byte(err.Error()), err
-			}
-			return []byte("NapCat Shell restarted"), nil
+		if _, err := os.Stat(exePath); err != nil {
+			return []byte("No NapCatWinBootMain.exe found"), fmt.Errorf("NapCat executable not found")
 		}
-		return []byte("No napcat.bat or NapCatWinBootMain.exe found"), fmt.Errorf("NapCat executable not found")
+		// Only kill if WebUI port is already down — don't destroy a working session-1 instance.
+		if !isPortReachable(6099) {
+			exec.Command("taskkill", "/F", "/IM", "NapCatWinBootMain.exe").Run()
+			exec.Command("taskkill", "/F", "/IM", "napcat.exe").Run()
+			exec.Command("taskkill", "/F", "/IM", "QQ.exe").Run()
+			time.Sleep(3 * time.Second)
+		} else {
+			log.Println("[NapCat] port 6099 is up — skipping kill, NapCat is alive")
+			return []byte("NapCat already running"), nil
+		}
+		// Write network config (WS+HTTP) before launching so NapCat picks it up.
+		ensureNapCatNetworkConfig(napcatDir)
+		if err := launchNapCatInUserSession(exePath, napcatDir); err != nil {
+			return []byte(err.Error()), err
+		}
+		return []byte("NapCat Shell restarted"), nil
 	}
 	// Linux/macOS: Docker
 	return dockerOutput("restart", "openclaw-qq")
+}
+
+// ensureNapCatNetworkConfig writes the OneBot network config (WS+HTTP) for all known
+// QQ UINs found in the NapCat config directory. NapCat reads onebot11_<uin>.json on
+// startup; if the file has an empty network block, ports 3001/3000 will never open.
+func ensureNapCatNetworkConfig(napcatShellDir string) {
+	// Find the inner napcat dir (where config/ lives)
+	innerDir := findNapCatInnerDir(napcatShellDir)
+	if innerDir == "" {
+		innerDir = napcatShellDir
+	}
+	cfgDir := filepath.Join(innerDir, "config")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		log.Printf("[NapCat] ensureNapCatNetworkConfig: mkdir %s: %v", cfgDir, err)
+		return
+	}
+
+	networkCfg := map[string]interface{}{
+		"network": map[string]interface{}{
+			"httpServers": []interface{}{
+				map[string]interface{}{
+					"name":              "ClawPanel-HTTP",
+					"enable":            true,
+					"port":              3000,
+					"host":              "0.0.0.0",
+					"enableCors":        true,
+					"enableWebsocket":   false,
+					"messagePostFormat": "array",
+					"token":             "",
+					"debug":             false,
+				},
+			},
+			"httpSseServers":   []interface{}{},
+			"httpClients":      []interface{}{},
+			"websocketServers": []interface{}{
+				map[string]interface{}{
+					"name":                "ClawPanel-WS",
+					"enable":              true,
+					"port":                3001,
+					"host":                "0.0.0.0",
+					"messagePostFormat":   "array",
+					"token":               "",
+					"reportSelfMessage":   false,
+					"enableForcePushEvent": true,
+					"debug":               false,
+					"heartInterval":       30000,
+				},
+			},
+			"websocketClients": []interface{}{},
+			"plugins":          []interface{}{},
+		},
+		"musicSignUrl":         "",
+		"enableLocalFile2Url":  false,
+		"parseMultMsg":         false,
+		"imageDownloadProxy":   "",
+	}
+	data, _ := json.MarshalIndent(networkCfg, "", "  ")
+
+	// Write for all existing onebot11_<uin>.json files, and also a default napcat.json
+	entries, _ := os.ReadDir(cfgDir)
+	uins := []string{}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, "onebot11_") && strings.HasSuffix(name, ".json") {
+			uin := strings.TrimSuffix(strings.TrimPrefix(name, "onebot11_"), ".json")
+			if uin != "" {
+				uins = append(uins, uin)
+			}
+		}
+	}
+	// Also check napcat_<uin>.json to find UINs even if onebot11 file doesn't exist yet
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, "napcat_") && strings.HasSuffix(name, ".json") &&
+			!strings.HasPrefix(name, "napcat_protocol_") {
+			uin := strings.TrimSuffix(strings.TrimPrefix(name, "napcat_"), ".json")
+			if uin != "" {
+				found := false
+				for _, u := range uins {
+					if u == uin {
+						found = true
+						break
+					}
+				}
+				if !found {
+					uins = append(uins, uin)
+				}
+			}
+		}
+	}
+
+	// Always write at least one config
+	if len(uins) == 0 {
+		p := filepath.Join(cfgDir, "onebot11.json")
+		if err := os.WriteFile(p, data, 0644); err != nil {
+			log.Printf("[NapCat] write %s: %v", p, err)
+		} else {
+			log.Printf("[NapCat] wrote default network config: %s", p)
+		}
+		return
+	}
+
+	for _, uin := range uins {
+		p := filepath.Join(cfgDir, "onebot11_"+uin+".json")
+		// Only overwrite if network is empty (don't clobber user customisations)
+		existing, err := os.ReadFile(p)
+		if err == nil {
+			var cur map[string]interface{}
+			if json.Unmarshal(existing, &cur) == nil {
+				if net, ok := cur["network"].(map[string]interface{}); ok {
+					wsServers, _ := net["websocketServers"].([]interface{})
+					httpServers, _ := net["httpServers"].([]interface{})
+					if len(wsServers) > 0 || len(httpServers) > 0 {
+						log.Printf("[NapCat] network config already set for UIN %s, skipping", uin)
+						continue
+					}
+				}
+			}
+		}
+		if err := os.WriteFile(p, data, 0644); err != nil {
+			log.Printf("[NapCat] write %s: %v", p, err)
+		} else {
+			log.Printf("[NapCat] wrote network config for UIN %s: %s", uin, p)
+		}
+	}
+}
+
+// findQQInstallDir returns the directory containing QQ.exe by checking running processes
+func findQQInstallDir() string {
+	// Try to find QQ.exe path from running processes via WMIC
+	out, err := exec.Command("wmic", "process", "where", "name='QQ.exe'", "get", "ExecutablePath", "/VALUE").Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(strings.ToLower(line), "executablepath=") {
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) == 2 && parts[1] != "" {
+					return filepath.Dir(strings.TrimSpace(parts[1]))
+				}
+			}
+		}
+	}
+	// Common QQ install locations
+	for _, p := range []string{`C:\Program Files\Tencent\QQ`, `D:\QQ`, `C:\QQ`, `D:\Program Files\Tencent\QQ`} {
+		if _, err := os.Stat(filepath.Join(p, "QQ.exe")); err == nil {
+			return p
+		}
+	}
+	return ""
 }
 
 // findNapCatShellDir finds the NapCat Shell installation directory on Windows
@@ -523,6 +673,9 @@ func findNapCatShellDir(cfg *config.Config) string {
 		`C:\NapCat`,
 		filepath.Join(home, "AppData", "Local", "NapCat"),
 	}
+	// Note: do NOT add the QQ install dir — NapCat Shell is a separate directory.
+	// QQ's own dir may contain NapCatWinBootMain.exe in subdirectories which would
+	// cause us to return the wrong dir.
 	markers := []string{"napcat.bat", "NapCatWinBootMain.exe"}
 	for _, dir := range candidates {
 		if _, err := os.Stat(dir); err != nil {
@@ -550,6 +703,79 @@ func findNapCatShellDir(cfg *config.Config) string {
 	return ""
 }
 
+// launchNapCatInUserSession launches NapCatWinBootMain.exe in the interactive user session.
+// ClawPanel runs as a SYSTEM service (session 0) and cannot directly start GUI processes
+// in session 1. We write a temp .ps1 file and use schtasks to run it as the interactive
+// user, which executes in their desktop session.
+// getInteractiveUsername returns the username of the currently logged-in interactive user.
+func getInteractiveUsername() string {
+	// WMIC outputs UTF-16LE; decode it properly.
+	out, err := exec.Command("wmic", "computersystem", "get", "UserName", "/VALUE").Output()
+	if err == nil {
+		text := decodeUTF16LE(out)
+		for _, line := range strings.Split(text, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(strings.ToLower(line), "username=") {
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+					return strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+	// Fallback: qwinsta.exe — shows active console sessions
+	out2, err := exec.Command(`C:\Windows\System32\qwinsta.exe`).Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out2), "\n") {
+			if strings.Contains(line, "Active") || strings.Contains(line, "活动") {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					u := strings.TrimPrefix(fields[0], ">")
+					if u != "" && !strings.EqualFold(u, "services") && !strings.EqualFold(u, "console") && !strings.HasPrefix(strings.ToLower(u), "rdp-") {
+						// qwinsta lists session name not username; use field[1] if field[0] looks like session name
+						if strings.HasPrefix(strings.ToLower(u), "console") || strings.HasPrefix(strings.ToLower(u), "rdp") {
+							u = fields[1]
+						}
+						return u
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// decodeUTF16LE decodes a UTF-16LE byte slice to a UTF-8 string.
+// WMIC on Windows outputs UTF-16LE; reading it as []byte gives garbled text.
+func decodeUTF16LE(b []byte) string {
+	// Strip BOM if present
+	if len(b) >= 2 && b[0] == 0xFF && b[1] == 0xFE {
+		b = b[2:]
+	}
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = uint16(b[2*i]) | uint16(b[2*i+1])<<8
+	}
+	var sb strings.Builder
+	for i := 0; i < len(u16); {
+		c := rune(u16[i])
+		i++
+		if c >= 0xD800 && c <= 0xDBFF && i < len(u16) {
+			low := rune(u16[i])
+			if low >= 0xDC00 && low <= 0xDFFF {
+				c = 0x10000 + (c-0xD800)*0x400 + (low - 0xDC00)
+				i++
+			}
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
+}
+
+
 func isPortReachable(port int) bool {
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 3*time.Second)
 	if err != nil {
@@ -573,25 +799,111 @@ func checkQQLoginStatus(cfg *config.Config) (loggedIn bool, nickname string, qqI
 	return
 }
 
+// readTokenFromNapCatLogs finds NapCat's logs dir (walking up/down from bootmain dir)
+// and extracts the live token logged as "[WebUi] WebUi Token: <token>".
+func readTokenFromNapCatLogs(bootmainDir string) string {
+	// Walk down from bootmain dir looking for a logs/ directory with .log files
+	logsDir := ""
+	filepath.WalkDir(bootmainDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || logsDir != "" {
+			return nil
+		}
+		if d.IsDir() && strings.EqualFold(d.Name(), "logs") {
+			entries, _ := os.ReadDir(path)
+			for _, e := range entries {
+				if strings.HasSuffix(strings.ToLower(e.Name()), ".log") {
+					logsDir = path
+					return filepath.SkipAll
+				}
+			}
+		}
+		return nil
+	})
+	// Also walk up parent dirs
+	if logsDir == "" {
+		dir := bootmainDir
+		for i := 0; i < 8; i++ {
+			candidate := filepath.Join(dir, "logs")
+			if entries, err := os.ReadDir(candidate); err == nil {
+				for _, e := range entries {
+					if strings.HasSuffix(strings.ToLower(e.Name()), ".log") {
+						logsDir = candidate
+						break
+					}
+				}
+			}
+			if logsDir != "" {
+				break
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	if logsDir == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return ""
+	}
+	var newest os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ".log") {
+			if newest == nil || e.Name() > newest.Name() {
+				newest = e
+			}
+		}
+	}
+	if newest == nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(logsDir, newest.Name()))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if idx := strings.Index(line, "[WebUi] WebUi Token: "); idx >= 0 {
+			tok := strings.TrimSpace(line[idx+len("[WebUi] WebUi Token: "):])
+			if tok != "" {
+				return tok
+			}
+		}
+	}
+	return ""
+}
+
 func doCheckQQLoginStatus(cfg *config.Config) (loggedIn bool, nickname string, qqID string) {
 	client := &http.Client{Timeout: 5 * time.Second}
 
-	// Use cached credential if available and fresh (< 10 minutes)
+	// Use cached credential if available and fresh (< 5 minutes)
+	// NapCat 4.x generates a new random token each startup — clear cache when it changes.
 	cred := ""
-	if cachedMonitorCred != "" && time.Since(cachedMonitorCredTime) < 10*time.Minute {
+	if cachedMonitorCred != "" && time.Since(cachedMonitorCredTime) < 5*time.Minute {
 		cred = cachedMonitorCred
 	} else {
-		// Get WebUI token: from local config file on Windows, from Docker on Linux
+		// Invalidate cache unconditionally so we always re-auth with the fresh token
+		cachedMonitorCred = ""
+		// Get WebUI token: from NapCat log (4.x uses random token per startup), or Docker
 		token := ""
 		if runtime.GOOS == "windows" {
 			napcatDir := findNapCatShellDir(cfg)
 			if napcatDir != "" {
-				webuiPath := filepath.Join(napcatDir, "config", "webui.json")
-				if data, err := os.ReadFile(webuiPath); err == nil {
-					var webui map[string]interface{}
-					if json.Unmarshal(data, &webui) == nil {
-						if t, ok := webui["token"].(string); ok && t != "" {
-							token = t
+				// NapCat 4.x: read token from latest log file
+				if tok := readTokenFromNapCatLogs(napcatDir); tok != "" {
+					token = tok
+				}
+				// Fallback: webui.json in bootmain config
+				if token == "" {
+					webuiPath := filepath.Join(napcatDir, "config", "webui.json")
+					if data, err := os.ReadFile(webuiPath); err == nil {
+						var webui map[string]interface{}
+						if json.Unmarshal(data, &webui) == nil {
+							if t, ok := webui["token"].(string); ok && t != "" {
+								token = t
+							}
 						}
 					}
 				}

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -144,34 +146,113 @@ func (m *Manager) Stop() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.status.Running || m.cmd == nil || m.cmd.Process == nil {
+	if !m.status.Running {
 		return fmt.Errorf("OpenClaw 未在运行")
 	}
 
 	log.Printf("[ProcessMgr] 正在停止 OpenClaw (PID: %d)...", m.status.PID)
 
-	// 先尝试优雅关闭
-	if runtime.GOOS == "windows" {
-		m.cmd.Process.Kill()
-	} else {
-		m.cmd.Process.Signal(os.Interrupt)
-		// 等待 5 秒，如果还没退出则强制杀死
-		done := make(chan struct{})
-		go func() {
-			m.cmd.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			m.cmd.Process.Kill()
+	gatewayPort := m.getGatewayPort()
+
+	// First, ask OpenClaw CLI to stop the daemon gateway process.
+	if bin := m.findOpenClawBin(); bin != "" {
+		cmd := exec.Command(bin, "gateway", "stop")
+		cmd.Dir = m.cfg.OpenClawDir
+		cmd.Env = append(buildProcessEnv(),
+			fmt.Sprintf("OPENCLAW_DIR=%s", m.cfg.OpenClawDir),
+			fmt.Sprintf("OPENCLAW_STATE_DIR=%s", m.cfg.OpenClawDir),
+			fmt.Sprintf("OPENCLAW_CONFIG_PATH=%s/openclaw.json", m.cfg.OpenClawDir),
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			log.Printf("[ProcessMgr] gateway stop 命令失败: %v (%s)", err, strings.TrimSpace(string(out)))
 		}
+	}
+
+	// Wait briefly for the gateway port to go down.
+	for i := 0; i < 10; i++ {
+		if !m.isPortListening(gatewayPort) {
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	// On Windows, if daemon still holds the port, force-kill by listening PID.
+	if runtime.GOOS == "windows" && m.isPortListening(gatewayPort) {
+		if killed := m.killWindowsPortListeners(gatewayPort); killed > 0 {
+			log.Printf("[ProcessMgr] 已强制终止 %d 个占用端口 %s 的进程", killed, gatewayPort)
+		}
+		for i := 0; i < 10; i++ {
+			if !m.isPortListening(gatewayPort) {
+				break
+			}
+			time.Sleep(300 * time.Millisecond)
+		}
+	}
+
+	// 先尝试优雅关闭
+	if m.cmd != nil && m.cmd.Process != nil {
+		if runtime.GOOS == "windows" {
+			_ = m.cmd.Process.Kill()
+		} else {
+			_ = m.cmd.Process.Signal(os.Interrupt)
+			// 等待 5 秒，如果还没退出则强制杀死
+			done := make(chan struct{})
+			go func() {
+				_ = m.cmd.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				_ = m.cmd.Process.Kill()
+			}
+		}
+	}
+
+	if m.isPortListening(gatewayPort) {
+		return fmt.Errorf("OpenClaw 网关端口 %s 仍被占用，停止失败", gatewayPort)
 	}
 
 	m.status.Running = false
 	m.status.PID = 0
 	log.Println("[ProcessMgr] OpenClaw 已停止")
 	return nil
+}
+
+func (m *Manager) killWindowsPortListeners(port string) int {
+	cmd := exec.Command("cmd", "/C", "netstat -ano -p tcp")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	pidSet := map[int]struct{}{}
+	needle := ":" + port
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(line, needle) || !strings.Contains(strings.ToUpper(line), "LISTENING") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[len(fields)-1])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		pidSet[pid] = struct{}{}
+	}
+	killed := 0
+	for pid := range pidSet {
+		k := exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/F")
+		if err := k.Run(); err == nil {
+			killed++
+		}
+	}
+	return killed
 }
 
 // Restart 重启 OpenClaw 进程
@@ -376,9 +457,8 @@ func (m *Manager) monitorDaemon(port string) {
 }
 
 // ensureOpenClawConfig 启动前检查并修复 openclaw.json 关键配置
-// 始终确保 gateway.mode=local；仅当 QQ 插件已安装且 NapCat 正在运行时
-// 才写入 channels.qq / plugins.entries.qq / plugins.installs.qq，
-// 避免用户不使用 QQ 插件时被强制写入导致 OpenClaw 网关启动失败。
+// 始终确保 gateway.mode=local；当 QQ 插件已安装时写入
+// channels.qq / plugins.entries.qq / plugins.installs.qq。
 func (m *Manager) ensureOpenClawConfig() {
 	ocDir := m.cfg.OpenClawDir
 	if ocDir == "" {
@@ -416,20 +496,33 @@ func (m *Manager) ensureOpenClawConfig() {
 		changed = true
 	}
 
-	// Only write QQ plugin config if:
-	//   1. The QQ extension directory is installed (extensions/qq exists), AND
-	//   2. NapCat is actually running (Docker container or Windows process)
-	// Without both conditions, injecting channels.qq causes OpenClaw gateway to
-	// fail on startup with "unknown channel id: qq" or similar errors.
+	// Remove keys rejected by some OpenClaw gateway versions.
+	if _, ok := cfg["meta"]; ok {
+		delete(cfg, "meta")
+		changed = true
+	}
+	if _, ok := cfg["workspace"]; ok {
+		delete(cfg, "workspace")
+		changed = true
+	}
+
+	// Write QQ plugin config when QQ extension is installed.
+	//
+	// Root cause fixed here:
+	// - Previously we only injected channels.qq when NapCat was already running.
+	// - If OpenClaw started before NapCat, QQ channel config was skipped and
+	//   incoming QQ messages could not be routed to OpenClaw, resulting in
+	//   "QQ receives message but no reply" symptoms.
+	//
+	// The actual safety condition is "QQ extension installed". Whether NapCat is
+	// currently online should not block channel config injection.
 	qqExtDir := filepath.Join(ocDir, "extensions", "qq")
 	qqInstalled := false
 	if _, err := os.Stat(qqExtDir); err == nil {
 		qqInstalled = true
-		m.normalizeQQPluginOwnership(qqExtDir)
 	}
-	napcatRunning := m.isNapCatRunning()
 
-	if qqInstalled && napcatRunning {
+	if qqInstalled {
 		// Ensure channels.qq with wsUrl
 		ch, _ := cfg["channels"].(map[string]interface{})
 		if ch == nil {
@@ -472,39 +565,26 @@ func (m *Manager) ensureOpenClawConfig() {
 			ins = map[string]interface{}{}
 			pl["installs"] = ins
 		}
-		if ins["qq"] == nil {
-			ins["qq"] = map[string]interface{}{
-				"installPath": qqExtDir,
-				"source":      "archive",
-				"version":     "1.0.0",
-			}
+		qqIns, _ := ins["qq"].(map[string]interface{})
+		if qqIns == nil {
+			qqIns = map[string]interface{}{}
+			ins["qq"] = qqIns
+		}
+		if p, _ := qqIns["installPath"].(string); p == "" {
+			qqIns["installPath"] = qqExtDir
+			changed = true
+		} else if _, err := os.Stat(p); err != nil {
+			qqIns["installPath"] = qqExtDir
 			changed = true
 		}
-	} else if qqInstalled && !napcatRunning {
-		log.Println("[ProcessMgr] QQ 插件已安装但 NapCat 未运行，跳过 channels.qq 配置注入")
-	}
-
-	// Fix invalid channel config values that cause OpenClaw gateway to refuse to start.
-	// e.g. whatsapp.dmPolicy must be one of "pairing"|"allowlist"|"open"|"disabled"
-	ch, _ := cfg["channels"].(map[string]interface{})
-	if ch != nil {
-		if wa, ok := ch["whatsapp"].(map[string]interface{}); ok {
-			validDmPolicy := map[string]bool{"pairing": true, "allowlist": true, "open": true, "disabled": true}
-			if dp, _ := wa["dmPolicy"].(string); dp != "" && !validDmPolicy[dp] {
-				log.Printf("[ProcessMgr] 修复无效 channels.whatsapp.dmPolicy 值 %q → \"disabled\"", dp)
-				wa["dmPolicy"] = "disabled"
-				ch["whatsapp"] = wa
-				cfg["channels"] = ch
-				changed = true
-			}
-			validGroupPolicy := map[string]bool{"pairing": true, "allowlist": true, "open": true, "disabled": true}
-			if gp, _ := wa["groupPolicy"].(string); gp != "" && !validGroupPolicy[gp] {
-				log.Printf("[ProcessMgr] 修复无效 channels.whatsapp.groupPolicy 值 %q → \"disabled\"", gp)
-				wa["groupPolicy"] = "disabled"
-				ch["whatsapp"] = wa
-				cfg["channels"] = ch
-				changed = true
-			}
+		source, _ := qqIns["source"].(string)
+		if source != "npm" && source != "archive" && source != "path" {
+			qqIns["source"] = "path"
+			changed = true
+		}
+		if qqIns["version"] == nil || qqIns["version"] == "" {
+			qqIns["version"] = "latest"
+			changed = true
 		}
 	}
 
@@ -515,28 +595,24 @@ func (m *Manager) ensureOpenClawConfig() {
 		} else if err := os.WriteFile(cfgPath, out, 0644); err != nil {
 			log.Printf("[ProcessMgr] openclaw.json 写入失败: %v", err)
 		} else {
-			log.Println("[ProcessMgr] openclaw.json 配置已自动修复 (gateway.mode/channels.qq/plugins/whatsapp)")
+			log.Println("[ProcessMgr] openclaw.json 配置已自动修复 (gateway.mode/channels.qq/plugins)")
 		}
 	}
 
-	// Patch QQ plugin channel.ts: startAccount must return a long-lived Promise
-	m.patchQQPluginChannelTS(ocDir)
-}
-
-// normalizeQQPluginOwnership ensures QQ extension ownership matches the running
-// service user (root in launchd/systemd deployments). Otherwise OpenClaw may
-// block the plugin as suspicious ownership and refuse to load channel "qq".
-func (m *Manager) normalizeQQPluginOwnership(qqExtDir string) {
-	if runtime.GOOS == "windows" {
-		return
+	// Patch QQ plugin channel implementation: startAccount must return
+	// a long-lived Promise (covers both src/channel.ts and dist/channel.js,
+	// and both config-local/extensions and npm-global install paths).
+	qqInstallPath := ""
+	if pl, ok := cfg["plugins"].(map[string]interface{}); ok {
+		if ins, ok := pl["installs"].(map[string]interface{}); ok {
+			if qqIns, ok := ins["qq"].(map[string]interface{}); ok {
+				if p, ok := qqIns["installPath"].(string); ok {
+					qqInstallPath = p
+				}
+			}
+		}
 	}
-	if os.Geteuid() != 0 {
-		return
-	}
-	cmd := exec.Command("chown", "-R", "0:0", qqExtDir)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Printf("[ProcessMgr] 修复 QQ 插件目录属主失败: %v (%s)", err, strings.TrimSpace(string(out)))
-	}
+	m.patchQQPluginChannel(ocDir, qqInstallPath)
 }
 
 // patchQQPluginChannelTS fixes the critical bug where the QQ plugin's startAccount
@@ -545,66 +621,114 @@ func (m *Manager) normalizeQQPluginOwnership(qqExtDir string) {
 // immediately (non-Promise return), the framework treats the account as exited
 // and triggers auto-restart attempts (up to 10), after which the channel handler
 // dies and incoming messages are never processed.
-func (m *Manager) patchQQPluginChannelTS(ocDir string) {
-	channelTS := filepath.Join(ocDir, "extensions", "qq", "src", "channel.ts")
-	data, err := os.ReadFile(channelTS)
-	if err != nil {
-		return // plugin not installed
+func (m *Manager) patchQQPluginChannel(ocDir, installPath string) {
+	paths := []string{}
+	if ocDir != "" {
+		paths = append(paths,
+			filepath.Join(ocDir, "extensions", "qq", "src", "channel.ts"),
+			filepath.Join(ocDir, "extensions", "qq", "dist", "channel.js"),
+		)
 	}
-	content := string(data)
-
-	// Already patched?
-	if strings.Contains(content, "new Promise") {
-		return
+	if installPath != "" {
+		paths = append(paths,
+			filepath.Join(installPath, "src", "channel.ts"),
+			filepath.Join(installPath, "dist", "channel.js"),
+		)
 	}
-	// Check for the broken pattern
-	if !strings.Contains(content, "return () => {") || !strings.Contains(content, "client.disconnect") {
-		return
+	if m.cfg != nil && m.cfg.OpenClawApp != "" {
+		paths = append(paths,
+			filepath.Join(m.cfg.OpenClawApp, "extensions", "qq", "src", "channel.ts"),
+			filepath.Join(m.cfg.OpenClawApp, "extensions", "qq", "dist", "channel.js"),
+		)
 	}
 
-	oldCode := `      client.connect();
-      
-      return () => {
-        client.disconnect();
-        clients.delete(account.accountId);
-        stopFileServer();
-      };`
-
-	newCode := `      client.connect();
-
-      // Return a Promise that stays pending until abortSignal fires.
-      // OpenClaw gateway expects startAccount to return a long-lived Promise;
-      // if it resolves immediately, the framework treats the account as exited
-      // and triggers auto-restart attempts.
-      const abortSignal = (ctx as any).abortSignal as AbortSignal | undefined;
-      return new Promise<void>((resolve) => {
+	oldPattern := regexp.MustCompile(`(?s)return\s*\(\)\s*=>\s*\{\s*client\.disconnect\(\);\s*clients\.delete\(account\.accountId\);\s*stopFileServer\(\);\s*\};`)
+	newReturn := `return new Promise((resolve) => {
         const cleanup = () => {
           client.disconnect();
           clients.delete(account.accountId);
           stopFileServer();
           resolve();
         };
+        const abortSignal = (ctx && ctx.abortSignal) ? ctx.abortSignal : undefined;
         if (abortSignal) {
           if (abortSignal.aborted) { cleanup(); return; }
           abortSignal.addEventListener("abort", cleanup, { once: true });
         }
-        // Also clean up if the WebSocket closes unexpectedly
         client.on("close", () => {
           cleanup();
         });
       });`
 
-	if !strings.Contains(content, oldCode) {
-		log.Println("[ProcessMgr] channel.ts 需要修复但模式不匹配，跳过自动补丁")
-		return
+	loggerPattern := regexp.MustCompile(`(?s)function\s+postLogEntry\s*\([^)]*\)\s*\{.*?\n\}`)
+	managerURLPattern := regexp.MustCompile(`const\s+MANAGER_LOG_URL\s*=\s*"[^"]*";`)
+	managerPort := 19527
+	if m.cfg != nil && m.cfg.Port > 0 {
+		managerPort = m.cfg.Port
+	}
+	managerURLLine := fmt.Sprintf(`const MANAGER_LOG_URL = "http://127.0.0.1:%d/api/events/log";`, managerPort)
+	loggerReplacement := `function postLogEntry(summary, detail, source) {
+  try {
+    const payload = {
+      source: source || "openclaw",
+      type: "openclaw.reply",
+      summary,
+      detail,
+    };
+    const f = (globalThis && globalThis.fetch) ? globalThis.fetch.bind(globalThis) : null;
+    if (f) {
+      f(MANAGER_LOG_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }).catch(() => {});
+    }
+  } catch {}
+}`
+
+	patchedAny := false
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		patched := content
+		fileChanged := false
+
+		if !strings.Contains(patched, "return new Promise") && oldPattern.MatchString(patched) {
+			patched = oldPattern.ReplaceAllString(patched, newReturn)
+			fileChanged = true
+		}
+
+		if managerURLPattern.MatchString(patched) {
+			next := managerURLPattern.ReplaceAllString(patched, managerURLLine)
+			if next != patched {
+				patched = next
+				fileChanged = true
+			}
+		}
+
+		if strings.Contains(patched, "const http = require(\"http\")") && loggerPattern.MatchString(patched) {
+			patched = loggerPattern.ReplaceAllString(patched, loggerReplacement)
+			fileChanged = true
+		}
+
+		if !fileChanged {
+			continue
+		}
+
+		if err := os.WriteFile(p, []byte(patched), 0644); err != nil {
+			log.Printf("[ProcessMgr] QQ channel 补丁写入失败 (%s): %v", p, err)
+			continue
+		}
+		patchedAny = true
+		log.Printf("[ProcessMgr] ✅ QQ channel 兼容补丁已应用: %s", p)
 	}
 
-	patched := strings.Replace(content, oldCode, newCode, 1)
-	if err := os.WriteFile(channelTS, []byte(patched), 0644); err != nil {
-		log.Printf("[ProcessMgr] channel.ts 补丁写入失败: %v", err)
-		return
+	if !patchedAny {
+		log.Println("[ProcessMgr] QQ channel 兼容补丁未命中（可能已修复或版本结构不同）")
 	}
-	log.Println("[ProcessMgr] ✅ channel.ts startAccount 已自动修复 (返回 long-lived Promise)")
 }
 
 // findOpenClawBin 查找 openclaw 可执行文件

--- a/web/src/components/AIAssistant.tsx
+++ b/web/src/components/AIAssistant.tsx
@@ -36,6 +36,29 @@ export default function AIAssistant() {
   const dragOffset = useRef({ x: 0, y: 0 });
   const resizeStart = useRef({ x: 0, y: 0, w: 0, h: 0 });
 
+  const loadModelConfig = useCallback(async () => {
+    try {
+      const r = await api.getOpenClawConfig();
+      if (!r.ok) return null;
+
+      const nextProviders = r.config?.models?.providers || {};
+      const nextPrimary = r.config?.agents?.defaults?.model?.primary || '';
+      setProviders(nextProviders);
+      setPrimaryModel(nextPrimary);
+
+      if (providerId && modelId) {
+        const models = nextProviders?.[providerId]?.models || [];
+        const exists = models.some((m: any) => (typeof m === 'string' ? m : m?.id) === modelId);
+        if (!exists) {
+          setProviderId('');
+          setModelId('');
+        }
+      }
+      return { providers: nextProviders, primary: nextPrimary };
+    } catch {}
+    return null;
+  }, [providerId, modelId]);
+
   // Initialize position to bottom-right
   useEffect(() => {
     if (open && pos.x === -1) {
@@ -46,14 +69,9 @@ export default function AIAssistant() {
   // Load model config
   useEffect(() => {
     if (open) {
-      api.getOpenClawConfig().then(r => {
-        if (r.ok) {
-          setProviders(r.config?.models?.providers || {});
-          setPrimaryModel(r.config?.agents?.defaults?.model?.primary || '');
-        }
-      }).catch(() => {});
+      loadModelConfig();
     }
-  }, [open]);
+  }, [open, loadModelConfig]);
 
   // Auto-scroll
   useEffect(() => {
@@ -112,8 +130,21 @@ export default function AIAssistant() {
     setLoading(true);
 
     try {
+      let effectiveProviderId = providerId;
+      let effectiveModelId = modelId;
+      const latest = await loadModelConfig();
+
+      if (latest && effectiveProviderId && effectiveModelId) {
+        const models = latest.providers?.[effectiveProviderId]?.models || [];
+        const exists = models.some((m: any) => (typeof m === 'string' ? m : m?.id) === effectiveModelId);
+        if (!exists) {
+          effectiveProviderId = '';
+          effectiveModelId = '';
+        }
+      }
+
       const chatHistory = [...messages, userMsg].slice(-20).map(m => ({ role: m.role, content: m.content }));
-      const r = await api.aiChat(chatHistory, providerId || undefined, modelId || undefined);
+      const r = await api.aiChat(chatHistory, effectiveProviderId || undefined, effectiveModelId || undefined);
       if (r.ok && r.reply) {
         setMessages(prev => [...prev, { role: 'assistant', content: r.reply, time: Date.now() }]);
       } else {

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -52,6 +52,30 @@ export function useWebSocket() {
     }).catch(() => {});
   }, []);
 
+  // Fallback polling: merge latest events in case websocket misses a push
+  useEffect(() => {
+    if (IS_DEMO) return;
+
+    const poll = () => {
+      api.getEvents({ limit: 80 }).then(r => {
+        if (!r.ok || !(r.events || r.entries)) return;
+        const incoming: LogEntry[] = (r.events || r.entries) as LogEntry[];
+
+        setLogEntries(prev => {
+          const idSet = new Set(prev.map(item => String(item.id)));
+          const additions = incoming.filter(item => !idSet.has(String(item.id)));
+          if (additions.length === 0) return prev;
+          const merged = [...additions, ...prev];
+          merged.sort((a, b) => b.time - a.time);
+          return merged.slice(0, 500);
+        });
+      }).catch(() => {});
+    };
+
+    const t = setInterval(poll, 3000);
+    return () => clearInterval(t);
+  }, []);
+
   // Demo mode: simulate periodic new log entries
   useEffect(() => {
     if (!IS_DEMO) return;

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -42,7 +42,8 @@ export default function Dashboard({ ws }: DashboardProps) {
   const adm = status?.admin || {};
 
   const todayStart = new Date(); todayStart.setHours(0,0,0,0);
-  const todayLogs = ws.logEntries.filter(e => e.time >= todayStart.getTime());
+  const filteredLogs = ws.logEntries.filter(e => !isNoiseEvent(e));
+  const todayLogs = filteredLogs.filter(e => e.time >= todayStart.getTime());
   const qqCount = todayLogs.filter(e => e.source === 'qq').length;
   const botCount = todayLogs.filter(e => e.source === 'openclaw').length;
 
@@ -188,7 +189,7 @@ export default function Dashboard({ ws }: DashboardProps) {
             </div>
             <div>
               <h3 className="font-bold text-sm text-gray-900 dark:text-white">{t.dashboard.recentActivity}</h3>
-              <p className="text-[10px] text-gray-500">{t.dashboard.realtimeLog} ({ws.logEntries.length})</p>
+               <p className="text-[10px] text-gray-500">{t.dashboard.realtimeLog} ({filteredLogs.length})</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -203,13 +204,13 @@ export default function Dashboard({ ws }: DashboardProps) {
           </div>
         </div>
         <div ref={logRef} className="flex-1 overflow-y-auto min-h-0 p-2 space-y-0.5">
-          {ws.logEntries.length === 0 && (
+          {filteredLogs.length === 0 && (
             <div className="h-full flex flex-col items-center justify-center text-gray-400 gap-2">
               <Clock size={32} className="opacity-20" />
               <p className="text-xs">{t.dashboard.noActivity}</p>
             </div>
           )}
-          {ws.logEntries.slice(0, 100).map((entry) => (
+          {filteredLogs.slice(0, 100).map((entry) => (
             <div key={entry.id} className="group">
               <div
                 className={`flex items-start gap-3 py-2 px-3 rounded-lg cursor-pointer transition-all duration-200 text-xs border border-transparent
@@ -308,4 +309,8 @@ function formatUptime(s: number, t: any) {
   if (s < 3600) return `${Math.floor(s / 60)}${t.dashboard.minutes}`;
   if (s < 86400) return `${Math.floor(s / 3600)}${t.dashboard.hours}${Math.floor((s % 3600) / 60)}${t.dashboard.minutes}`;
   return `${Math.floor(s / 86400)}${t.dashboard.days}${Math.floor((s % 86400) / 3600)}${t.dashboard.hours}`;
+}
+
+function isNoiseEvent(entry: { source: string; type: string; summary: string }) {
+  return entry.source === 'qq' && entry.type === 'notice.notify';
 }


### PR DESCRIPTION
## Summary
- 修复 Windows 下 NapCat 启停与会话拉起链路，增强重连判定与 WebUI/端口状态处理，避免误判在线或反复重启。
- 修复 OpenClaw 与 QQ 事件链路：`/api/events/log` 写库后实时广播，前端增加 websocket 兜底轮询与噪音事件过滤，确保回复与日志实时可见。
- 增强 Windows 配置路径与插件自修复逻辑，避免 `systemprofile` 路径污染并提升 QQ 插件配置稳定性。

## Validation
- 已完成前端构建：`npm run build`（web）
- 当前环境缺少 `go` 命令，后端构建需在有 Go 环境的机器补跑