### PR TITLE
Fix workspace skill discovery in Skills page

### DIFF
--- a/Debug/2026-03-08-issue-38-skill-scan.md
+++ b/Debug/2026-03-08-issue-38-skill-scan.md
@@ -1,0 +1,28 @@
+# 2026-03-08 issue 38 本地技能扫描修复记录
+
+## 问题
+
+- 技能中心无法加载部分本地 skills。
+- 用户反馈通过 OpenClaw 下载到 workspace 下的技能目录没有被 ClawPanel 扫描出来。
+
+## 定位
+
+- `internal/handler/skills.go` 只扫描 `cfg.OpenClawWork/skills`、`OpenClawDir/skills` 和 app skills。
+- 但 OpenClaw 的真实技能落点可能来自 `openclaw.json` 里的 `workspace.path`，或者来自 `agents.list[].workspace`。
+- 当运行时工作目录与 `cfg.OpenClawWork` 不一致时，技能页只能看到默认扫描路径中的少量技能。
+
+## 修复
+
+- 扩展技能扫描路径解析：
+  - 保留 `cfg.OpenClawWork/skills`
+  - 新增 `openclaw.json -> workspace.path/skills`
+  - 新增 `openclaw.json -> agents.list[].workspace/skills`
+- 对相对路径统一基于 `OpenClawDir` 的父目录做绝对化处理。
+- 增加去重逻辑，避免同一技能目录被重复扫描。
+- 补充单测，覆盖 workspace path 与 agent workspace 两类来源。
+
+## 验证建议
+
+- 在 OpenClaw 的 `workspace.path/skills` 下放置技能目录后刷新技能页，确认可见。
+- 给某个 agent 单独配置 workspace，并在其 `skills` 子目录下放置技能，确认也能被发现。
+- 若仍缺失，再检查对应目录下是否存在合法技能文件结构。

--- a/internal/handler/skills.go
+++ b/internal/handler/skills.go
@@ -114,26 +114,13 @@ func GetSkills(cfg *config.Config) gin.HandlerFunc {
 		}
 
 		// --- 扫描技能 ---
-		// 1. OPENCLAW_DIR/skills
-		scanSkillDir(filepath.Join(cfg.OpenClawDir, "skills"), "skill", false, blockSet, &skills, seen)
-
-		// 2. Workspace work/skills
-		workDir := cfg.OpenClawWork
-		if workDir == "" {
-			workDir = filepath.Join(filepath.Dir(cfg.OpenClawDir), "work")
+		for _, candidate := range resolveWorkspaceSkillDirs(cfg, ocConfig) {
+			scanSkillDir(candidate, "workspace", false, blockSet, &skills, seen)
 		}
-		scanSkillDir(filepath.Join(workDir, "skills"), "workspace", false, blockSet, &skills, seen)
-
-		// 3. App skills
-		appDir := cfg.OpenClawApp
-		candidates := []string{}
-		if appDir != "" {
-			candidates = append(candidates, filepath.Join(appDir, "skills"))
+		for _, candidate := range resolveOpenClawSkillDirs(cfg) {
+			scanSkillDir(candidate, "skill", false, blockSet, &skills, seen)
 		}
-		candidates = append(candidates,
-			filepath.Join(filepath.Dir(cfg.OpenClawDir), "app", "skills"),
-		)
-		for _, candidate := range candidates {
+		for _, candidate := range resolveAppSkillDirs(cfg) {
 			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
 				scanSkillDir(candidate, "app-skill", true, blockSet, &skills, seen)
 				break
@@ -149,6 +136,86 @@ func GetSkills(cfg *config.Config) gin.HandlerFunc {
 
 		c.JSON(http.StatusOK, gin.H{"ok": true, "skills": skills, "plugins": pluginsList})
 	}
+}
+
+func resolveOpenClawSkillDirs(cfg *config.Config) []string {
+	return uniqueSkillDirs(filepath.Join(cfg.OpenClawDir, "skills"))
+}
+
+func resolveWorkspaceSkillDirs(cfg *config.Config, ocConfig map[string]interface{}) []string {
+	parentDir := filepath.Dir(cfg.OpenClawDir)
+	roots := []string{}
+
+	if cfg.OpenClawWork != "" {
+		roots = append(roots, cfg.OpenClawWork)
+	} else {
+		roots = append(roots, filepath.Join(parentDir, "work"))
+	}
+
+	if workspace, ok := ocConfig["workspace"].(map[string]interface{}); ok {
+		if path := normalizeSkillRootPath(parentDir, toString(workspace["path"])); path != "" {
+			roots = append(roots, path)
+		}
+	}
+
+	if agents, ok := ocConfig["agents"].(map[string]interface{}); ok {
+		if list, ok := agents["list"].([]interface{}); ok {
+			for _, raw := range list {
+				item, _ := raw.(map[string]interface{})
+				if item == nil {
+					continue
+				}
+				if path := normalizeSkillRootPath(parentDir, toString(item["workspace"])); path != "" {
+					roots = append(roots, path)
+				}
+			}
+		}
+	}
+
+	skillDirs := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		skillDirs = append(skillDirs, filepath.Join(root, "skills"))
+	}
+	return uniqueSkillDirs(skillDirs...)
+}
+
+func resolveAppSkillDirs(cfg *config.Config) []string {
+	parentDir := filepath.Dir(cfg.OpenClawDir)
+	candidates := []string{}
+	if cfg.OpenClawApp != "" {
+		candidates = append(candidates, filepath.Join(cfg.OpenClawApp, "skills"))
+	}
+	candidates = append(candidates, filepath.Join(parentDir, "app", "skills"))
+	return uniqueSkillDirs(candidates...)
+}
+
+func normalizeSkillRootPath(parentDir, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	path := filepath.Clean(raw)
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(parentDir, path)
+	}
+	return filepath.Clean(path)
+}
+
+func uniqueSkillDirs(paths ...string) []string {
+	seen := map[string]bool{}
+	result := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = filepath.Clean(strings.TrimSpace(p))
+		if p == "." || p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		result = append(result, p)
+	}
+	return result
 }
 
 // ToggleSkill 切换技能启用/禁用

--- a/internal/handler/skills_test.go
+++ b/internal/handler/skills_test.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zhaoxinyi02/ClawPanel/internal/config"
+)
+
+func TestResolveWorkspaceSkillDirsIncludesWorkspacePathAndAgentWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	base := filepath.Join(root, ".openclaw")
+	cfg := &config.Config{
+		OpenClawDir:  base,
+		OpenClawWork: filepath.Join(root, "work"),
+	}
+	ocConfig := map[string]interface{}{
+		"workspace": map[string]interface{}{
+			"path": "workspace-data",
+		},
+		"agents": map[string]interface{}{
+			"list": []interface{}{
+				map[string]interface{}{"id": "main", "workspace": "agents/main-workspace"},
+				map[string]interface{}{"id": "ops", "workspace": filepath.Join(root, "external", "ops-workspace")},
+			},
+		},
+	}
+
+	dirs := resolveWorkspaceSkillDirs(cfg, ocConfig)
+	parent := filepath.Dir(base)
+	expected := []string{
+		filepath.Join(cfg.OpenClawWork, "skills"),
+		filepath.Join(parent, "workspace-data", "skills"),
+		filepath.Join(parent, "agents", "main-workspace", "skills"),
+		filepath.Join(root, "external", "ops-workspace", "skills"),
+	}
+
+	if len(dirs) != len(expected) {
+		t.Fatalf("expected %d dirs, got %d: %#v", len(expected), len(dirs), dirs)
+	}
+	for i, want := range expected {
+		if dirs[i] != filepath.Clean(want) {
+			t.Fatalf("dir[%d] = %q, want %q", i, dirs[i], filepath.Clean(want))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expand local skill scanning to include workspace roots declared in `openclaw.json`, including `workspace.path` and agent-specific `workspace` directories
- normalize and deduplicate resolved skill directories so downloaded workspace skills can appear reliably in the Skills page
- add a focused debug note and unit test covering workspace-based skill discovery