### PR TITLE
Allow non-root ClawPanel service installs

### DIFF
--- a/Debug/2026-03-08-issue-40-service-user.md
+++ b/Debug/2026-03-08-issue-40-service-user.md
@@ -1,0 +1,27 @@
+# 2026-03-08 issue 40 网关重启用户身份修复记录
+
+## 问题
+
+- Linux 安装脚本把 systemd 服务用户写死为 `root`。
+- 这样 ClawPanel 启动后的 OpenClaw 网关和后续重启流程都会沿用 root 身份，不利于最小权限运行，也不方便使用自定义用户目录。
+
+## 定位
+
+- `scripts/install.sh` 在生成 systemd service 时固定写入 `User=root`。
+- 只要服务本身以 root 启动，后续面板内的网关启动/重启也会自然沿用 root 上下文。
+
+## 修复
+
+- 安装脚本新增服务用户解析逻辑：
+  - 优先读取 `CLAWPANEL_SERVICE_USER`
+  - 否则优先使用 `sudo` 调用者 `SUDO_USER`
+  - 最后才回退到 `root`
+- 自动解析并写入对应 `Group=`。
+- 安装时将 `${INSTALL_DIR}` 归属调整给服务用户，确保非 root 服务账户也能正常运行。
+- systemd service 中补充 `HOME=~service_user`，避免运行时仍落到 root 家目录上下文。
+
+## 验证建议
+
+- 使用 `sudo bash install.sh` 安装后执行 `systemctl cat clawpanel`，确认 `User=` 不是固定 root。
+- 在需要自定义账户时，执行 `CLAWPANEL_SERVICE_USER=youruser sudo bash install.sh`。
+- 安装完成后通过面板触发网关重启，确认 OpenClaw 相关文件与进程归属符合预期用户。

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,6 +121,53 @@ get_ip() {
     fi
 }
 
+resolve_service_user() {
+    local user="${CLAWPANEL_SERVICE_USER:-}"
+    if [ -n "$user" ]; then
+        echo "$user"
+        return
+    fi
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        echo "$SUDO_USER"
+        return
+    fi
+    echo "root"
+}
+
+resolve_service_group() {
+    local user="$1"
+    if [ -z "$user" ]; then
+        echo "root"
+        return
+    fi
+    if command -v id &>/dev/null; then
+        id -gn "$user" 2>/dev/null || echo "$user"
+        return
+    fi
+    echo "$user"
+}
+
+resolve_service_home() {
+    local user="$1"
+    if [ -z "$user" ]; then
+        echo "/root"
+        return
+    fi
+    if command -v getent &>/dev/null; then
+        local home
+        home=$(getent passwd "$user" | cut -d: -f6)
+        if [ -n "$home" ]; then
+            echo "$home"
+            return
+        fi
+    fi
+    if [ "$user" = "root" ]; then
+        echo "/root"
+        return
+    fi
+    echo "/home/${user}"
+}
+
 # ==================== 主安装流程 ====================
 main() {
     print_banner
@@ -134,9 +181,14 @@ main() {
     local SYS_ARCH=$(detect_arch)
     local BINARY_FILE="${BINARY_NAME}-v${VERSION}-${SYS_OS}-${SYS_ARCH}"
     local TOTAL_STEPS=5
+    local SERVICE_USER=$(resolve_service_user)
+    local SERVICE_GROUP=$(resolve_service_group "$SERVICE_USER")
+    local SERVICE_HOME=$(resolve_service_home "$SERVICE_USER")
 
     info "系统信息: ${SYS_OS}/${SYS_ARCH}"
     info "安装目录: ${INSTALL_DIR}"
+    info "服务用户: ${SERVICE_USER}:${SERVICE_GROUP}"
+    info "服务目录: ${SERVICE_HOME}"
     echo ""
 
     # ---- Step 1: 创建目录 ----
@@ -162,6 +214,7 @@ main() {
     fi
 
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    chown -R "${SERVICE_USER}:${SERVICE_GROUP}" "${INSTALL_DIR}" 2>/dev/null || true
     local FILE_SIZE=$(du -h "${INSTALL_DIR}/${BINARY_NAME}" | awk '{print $1}')
     log "下载完成 (${FILE_SIZE})"
 
@@ -179,13 +232,15 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=root
+User=${SERVICE_USER}
+Group=${SERVICE_GROUP}
 WorkingDirectory=${INSTALL_DIR}
 ExecStart=${INSTALL_DIR}/${BINARY_NAME}
 Restart=always
 RestartSec=5
 LimitNOFILE=65535
 Environment=CLAWPANEL_DATA=${INSTALL_DIR}/data
+Environment=HOME=${SERVICE_HOME}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- stop hardcoding the Linux systemd service user to `root` and instead resolve a service account from `CLAWPANEL_SERVICE_USER` or the invoking `SUDO_USER`
- set the matching group, home directory, and install directory ownership so gateway restart flows can run under the intended user context
- add a debug note documenting the service-user reasoning and validation steps for issue 40