### PR TITLE
fix: preserve Windows OpenClaw restart reliability

### DIFF
--- a/internal/config/runtime_env.go
+++ b/internal/config/runtime_env.go
@@ -70,6 +70,8 @@ func DetectOpenClawBinaryPath() string {
 	if runtime.GOOS == "windows" {
 		candidates = append(candidates,
 			filepath.Join(home, "AppData", "Roaming", "npm", "openclaw.cmd"),
+			`C:\ClawPanel\npm-global\openclaw.cmd`,
+			`C:\ClawPanel\npm-global\node_modules\.bin\openclaw.cmd`,
 			`C:\Program Files\nodejs\openclaw.cmd`,
 		)
 	} else {

--- a/internal/handler/software.go
+++ b/internal/handler/software.go
@@ -1270,6 +1270,22 @@ function Refresh-Path {
   $env:PATH = ($paths | Where-Object { $_ } | Select-Object -Unique) -join ";"
 }
 
+function Invoke-NativeStep([scriptblock]$Command) {
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = "Continue"
+  try {
+    & $Command 2>&1 | ForEach-Object {
+      $text = $_.ToString()
+      if (-not [string]::IsNullOrWhiteSpace($text)) {
+        Write-Output $text.TrimEnd()
+      }
+    }
+    return $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousPreference
+  }
+}
+
 function Get-NodeCommand {
   $cmd = Get-Command node -ErrorAction SilentlyContinue
   if ($cmd) { return $cmd }
@@ -1402,15 +1418,19 @@ if (-not (Test-Path $npmModules)) {
 }
 
 Write-Output "📥 正在通过 npm 安装 OpenClaw..."
-npm install -g openclaw@latest --registry=https://registry.npmmirror.com 2>&1
-if ($LASTEXITCODE -ne 0) {
-  Write-Output "⚠️ 首次安装失败 (exit code: $LASTEXITCODE)，正在重试..."
-  # Retry with force flag
-  npm install -g openclaw@latest --registry=https://registry.npmmirror.com --force 2>&1
-  if ($LASTEXITCODE -ne 0) {
-    Write-Output "❌ OpenClaw 安装失败，请检查网络连接或手动运行: npm install -g openclaw@latest"
-    exit 1
-  }
+$npmExit = Invoke-NativeStep { npm install -g openclaw@latest --registry=https://registry.npmmirror.com --no-fund --no-audit }
+$openclawCmd = Join-Path $npmPrefix "openclaw.cmd"
+if ($npmExit -ne 0 -and -not (Test-Path $openclawCmd)) {
+  Write-Output "⚠️ 首次安装失败 (exit code: $npmExit)，正在重试..."
+  Invoke-NativeStep { npm cache verify } | Out-Null
+  $npmExit = Invoke-NativeStep { npm install -g openclaw@latest --registry=https://registry.npmmirror.com --force --no-fund --no-audit }
+}
+if ($npmExit -ne 0 -and -not (Test-Path $openclawCmd)) {
+  Write-Output "❌ OpenClaw 安装失败，请检查网络连接或手动运行: npm install -g openclaw@latest"
+  exit 1
+}
+if ($npmExit -ne 0 -and (Test-Path $openclawCmd)) {
+  Write-Output "⚠️ npm 返回退出码 $npmExit，但 openclaw 已安装成功，继续初始化配置"
 }
 
 # Refresh PATH so we can find openclaw.cmd
@@ -1474,6 +1494,16 @@ if (-not (Test-Path $openclawConfig)) {
 "@ | Set-Content $openclawConfig -Force
   Write-Output "✅ 配置文件已创建: $openclawConfig"
 }
+if (Test-Path $openclawCmd) {
+  $env:OPENCLAW_DIR = $openclawDir
+  $env:OPENCLAW_STATE_DIR = $openclawDir
+  $env:OPENCLAW_CONFIG_PATH = $openclawConfig
+  $initExit = Invoke-NativeStep { & $openclawCmd init }
+  if ($initExit -ne 0) {
+    Write-Output "⚠️ OpenClaw 初始化返回退出码 $initExit，通常稍后网关仍会继续拉起"
+  }
+}
+Write-Output "ℹ️ 初次安装后，网关状态同步可能需要 10-30 秒"
 Write-Output "✅ 全部完成"
 `
 			} else {

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -174,9 +176,23 @@ func Restore(cfg *config.Config) gin.HandlerFunc {
 func RestartGateway(cfg *config.Config, procMgr *process.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		patchModelsJSON(cfg)
+		status := procMgr.GetStatus()
+
+		if status.ManagedExternally || status.Daemonized {
+			if err := restartGatewayViaCLI(cfg, procMgr); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": "通过 CLI 重启网关失败: " + err.Error()})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已通过 CLI 发起网关重启"})
+			return
+		}
 
 		// If OpenClaw process is not running, start it
-		if !procMgr.GetStatus().Running {
+		if !status.Running {
+			if err := restartGatewayViaCLI(cfg, procMgr); err == nil {
+				c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已通过 CLI 拉起网关"})
+				return
+			}
 			if err := procMgr.Start(); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": "启动 OpenClaw 失败: " + err.Error()})
 				return
@@ -185,16 +201,174 @@ func RestartGateway(cfg *config.Config, procMgr *process.Manager) gin.HandlerFun
 			return
 		}
 
-		signalPath := filepath.Join(cfg.OpenClawDir, "restart-gateway-signal.json")
-		data, _ := json.Marshal(map[string]interface{}{
-			"requestedAt": time.Now().Format(time.RFC3339),
-		})
-		if err := os.WriteFile(signalPath, data, 0644); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": err.Error()})
-			return
+		if err := procMgr.Restart(); err != nil {
+			if cliErr := restartGatewayViaCLI(cfg, procMgr); cliErr == nil {
+				c.JSON(http.StatusOK, gin.H{"ok": true, "message": "进程内重启失败，已回退到 CLI 发起网关重启"})
+				return
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": "重启 OpenClaw 网关失败: " + err.Error() + " | CLI 回退失败: " + cliErr.Error()})
+				return
+			}
 		}
-		c.JSON(http.StatusOK, gin.H{"ok": true, "message": "网关重启请求已发送"})
+		c.JSON(http.StatusOK, gin.H{"ok": true, "message": "OpenClaw 网关已重启"})
 	}
+}
+
+func restartGatewayViaCLI(cfg *config.Config, procMgr *process.Manager) error {
+	bins := candidateOpenClawBins(cfg)
+	errMsgs := make([]string, 0, len(bins))
+	for _, bin := range bins {
+		if err := restartGatewayWithBinary(cfg, procMgr, bin); err == nil {
+			return nil
+		} else {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+	if len(errMsgs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errMsgs, " | "))
+	}
+	return fmt.Errorf("未找到可用的 openclaw 启动命令")
+}
+
+func candidateOpenClawBins(cfg *config.Config) []string {
+	bins := []string{}
+	if p := config.DetectOpenClawBinaryPath(); p != "" {
+		bins = append(bins, p)
+	}
+	if cfg != nil {
+		if app := strings.TrimSpace(cfg.OpenClawApp); app != "" {
+			if runtime.GOOS == "windows" {
+				bins = append(bins,
+					filepath.Join(filepath.Dir(app), "npm-global", "openclaw.cmd"),
+					filepath.Join(filepath.Dir(app), "npm-global", "node_modules", ".bin", "openclaw.cmd"),
+				)
+			} else {
+				bins = append(bins, filepath.Join(filepath.Dir(app), ".npm-global", "bin", "openclaw"))
+			}
+		}
+		if runtime.GOOS == "windows" {
+			bins = append(bins,
+				filepath.Join(filepath.Dir(cfg.OpenClawDir), "npm-global", "openclaw.cmd"),
+				filepath.Join(filepath.Dir(cfg.OpenClawDir), "npm-global", "node_modules", ".bin", "openclaw.cmd"),
+			)
+		}
+	}
+	bins = append(bins, "openclaw")
+
+	seen := map[string]struct{}{}
+	uniq := make([]string, 0, len(bins))
+	for _, bin := range bins {
+		bin = strings.TrimSpace(bin)
+		if bin == "" {
+			continue
+		}
+		if _, ok := seen[bin]; ok {
+			continue
+		}
+		seen[bin] = struct{}{}
+		uniq = append(uniq, bin)
+	}
+	return uniq
+}
+
+func restartGatewayWithBinary(cfg *config.Config, procMgr *process.Manager, bin string) error {
+	env := append(config.BuildExecEnv(),
+		fmt.Sprintf("OPENCLAW_DIR=%s", cfg.OpenClawDir),
+		fmt.Sprintf("OPENCLAW_STATE_DIR=%s", cfg.OpenClawDir),
+		fmt.Sprintf("OPENCLAW_CONFIG_PATH=%s", filepath.Join(cfg.OpenClawDir, "openclaw.json")),
+	)
+
+	if restartErr, restartOut := runGatewayCommand(cfg, env, bin, "gateway", "restart"); restartErr == nil {
+		if procMgr == nil || waitGatewayState(procMgr, true, gatewayStartWaitTimeout()) {
+			return nil
+		}
+		_ = restartOut
+	} else if procMgr != nil && waitGatewayState(procMgr, true, 3*time.Second) {
+		return nil
+	}
+
+	stopErr, stopOut := runGatewayCommand(cfg, env, bin, "gateway", "stop")
+	if stopErr != nil {
+		_ = stopOut
+	}
+
+	if procMgr != nil {
+		_ = waitGatewayState(procMgr, false, 8*time.Second)
+	}
+
+	startVariants := [][]string{{"gateway"}, {"gateway", "start"}}
+	startErrs := make([]string, 0, len(startVariants))
+	for _, args := range startVariants {
+		cmd := exec.Command(bin, args...)
+		cmd.Dir = cfg.OpenClawDir
+		cmd.Env = env
+		if err := cmd.Start(); err != nil {
+			startErrs = append(startErrs, fmt.Sprintf("%s: %v", strings.Join(args, " "), err))
+			continue
+		}
+		go func(c *exec.Cmd) {
+			_, _ = c.Process.Wait()
+		}(cmd)
+
+		if procMgr == nil {
+			return nil
+		}
+		if waitGatewayState(procMgr, true, gatewayStartWaitTimeout()) {
+			return nil
+		}
+		startErrs = append(startErrs, fmt.Sprintf("%s: 网关未在超时时间内就绪", strings.Join(args, " ")))
+	}
+
+	msg := fmt.Sprintf("%s 重启失败", bin)
+	if stopErr != nil {
+		msg += "; stop: " + strings.TrimSpace(stopOut)
+	}
+	if len(startErrs) > 0 {
+		msg += "; start: " + strings.Join(startErrs, " | ")
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func runGatewayCommand(cfg *config.Config, env []string, bin string, args ...string) (error, string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = cfg.OpenClawDir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("命令超时"), string(out)
+	}
+	return err, string(out)
+}
+
+func waitGatewayState(procMgr *process.Manager, expected bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if gatewayStateMatches(procMgr, expected) {
+			return true
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return gatewayStateMatches(procMgr, expected)
+}
+
+func gatewayStateMatches(procMgr *process.Manager, expected bool) bool {
+	if procMgr == nil {
+		return false
+	}
+	status := procMgr.GetStatus()
+	if expected {
+		return status.Running || procMgr.GatewayListening()
+	}
+	return !status.Running && !procMgr.GatewayListening()
+}
+
+func gatewayStartWaitTimeout() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 30 * time.Second
+	}
+	return 15 * time.Second
 }
 
 // RestartPanel 重启 ClawPanel 自身 (通过 systemctl)

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -54,6 +54,13 @@ type Manager struct {
 
 const gatewayProbeCacheTTL = 3 * time.Second
 
+func gatewayStartupTimeout() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 30 * time.Second
+	}
+	return 15 * time.Second
+}
+
 var (
 	tailnetIPv4Net = mustCIDR("100.64.0.0/10")
 	tailnetIPv6Net = mustCIDR("fd7a:115c:a1e0::/48")
@@ -363,6 +370,16 @@ func (m *Manager) GetStatus() Status {
 		s.ExitCode = 0
 		s.Daemonized = false
 		s.ManagedExternally = true
+		return s
+	}
+	if pid, ok := m.detectExternalGatewayProcess(); ok {
+		s.Running = true
+		s.PID = pid
+		s.StartedAt = time.Time{}
+		s.Uptime = 0
+		s.ExitCode = 0
+		s.Daemonized = false
+		s.ManagedExternally = true
 	}
 	return s
 }
@@ -451,8 +468,8 @@ func (m *Manager) waitForExit() {
 		// process "openclaw-gateway" that holds the port, then the parent
 		// exits (often with code 1). If the gateway port is listening after
 		// the parent exits, the daemon started successfully.
-		if wasRunning && !daemonized && !startedAt.IsZero() && time.Since(startedAt) < 15*time.Second {
-			if m.waitForGatewayReady(8 * time.Second) {
+		if wasRunning && !daemonized && !startedAt.IsZero() && time.Since(startedAt) < 20*time.Second {
+			if m.waitForGatewayReady(gatewayStartupTimeout()) {
 				log.Printf("[ProcessMgr] OpenClaw 父进程已退出但网关守护进程仍可探测（daemon fork 模式），视为正常")
 				m.mu.Lock()
 				m.status.Running = true
@@ -703,23 +720,53 @@ func (m *Manager) isOpenClawGateway(host, port string) bool {
 		Timeout:   1500 * time.Millisecond,
 		Transport: &http.Transport{},
 	}
-	u := (&url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort(host, port),
-		Path:   "/",
-	}).String()
-	resp, err := client.Get(u)
-	if err != nil {
-		return false
+	for _, path := range []string{"/healthz", "/health", "/"} {
+		u := (&url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(host, port),
+			Path:   path,
+		}).String()
+		resp, err := client.Get(u)
+		if err != nil {
+			continue
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+		if readErr != nil {
+			continue
+		}
+		if looksLikeOpenClawGatewayResponse(path, resp.StatusCode, resp.Header, body) {
+			return true
+		}
 	}
-	defer resp.Body.Close()
+	return false
+}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if err != nil {
-		return false
-	}
+func looksLikeOpenClawGatewayResponse(path string, statusCode int, headers http.Header, body []byte) bool {
 	text := strings.ToLower(string(body))
-	return strings.Contains(text, "openclaw control") || strings.Contains(text, "<openclaw-app")
+	contentType := strings.ToLower(headers.Get("Content-Type"))
+	server := strings.ToLower(headers.Get("Server"))
+	location := strings.ToLower(headers.Get("Location"))
+
+	if strings.Contains(server, "openclaw") {
+		return true
+	}
+	if strings.Contains(location, "openclaw") || strings.Contains(location, "control") {
+		return true
+	}
+	if strings.Contains(text, "openclaw control") || strings.Contains(text, "<openclaw-app") {
+		return true
+	}
+
+	if path == "/health" || path == "/healthz" {
+		if statusCode >= 200 && statusCode < 500 {
+			if strings.Contains(contentType, "json") && (strings.Contains(text, "\"ok\":true") || strings.Contains(text, "\"status\":\"ok\"") || strings.Contains(text, "\"status\":\"live\"") || strings.Contains(text, "healthy") || strings.Contains(text, "openclaw")) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (m *Manager) waitForGatewayReady(timeout time.Duration) bool {
@@ -747,6 +794,95 @@ func (m *Manager) isPortListening(port string) bool {
 		return true
 	}
 	return false
+}
+
+func (m *Manager) detectExternalGatewayProcess() (int, bool) {
+	port := m.getGatewayPort()
+	if port == "" {
+		return 0, false
+	}
+	pids, err := listeningPIDsForPort(port)
+	if err != nil {
+		return 0, false
+	}
+	for _, pid := range pids {
+		if pid <= 0 {
+			continue
+		}
+		cmdline, err := processCommandLine(pid)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(cmdline)
+		if strings.Contains(lower, "openclaw") && strings.Contains(lower, "gateway") {
+			return pid, true
+		}
+	}
+	return 0, false
+}
+
+func listeningPIDsForPort(port string) ([]int, error) {
+	if runtime.GOOS == "windows" {
+		out, err := exec.Command("netstat", "-ano", "-p", "tcp").Output()
+		if err != nil {
+			return nil, err
+		}
+		needle := ":" + port
+		seen := map[int]struct{}{}
+		var pids []int
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || !strings.Contains(line, needle) || !strings.Contains(line, "LISTENING") {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) < 5 {
+				continue
+			}
+			pid, err := strconv.Atoi(parts[len(parts)-1])
+			if err != nil {
+				continue
+			}
+			if _, ok := seen[pid]; ok {
+				continue
+			}
+			seen[pid] = struct{}{}
+			pids = append(pids, pid)
+		}
+		return pids, nil
+	}
+	out, err := exec.Command("lsof", "-nP", "-iTCP:"+port, "-sTCP:LISTEN", "-t").Output()
+	if err != nil {
+		return nil, err
+	}
+	seen := map[int]struct{}{}
+	var pids []int
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+func processCommandLine(pid int) (string, error) {
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command("powershell.exe", "-NoProfile", "-Command", fmt.Sprintf("$p=Get-CimInstance Win32_Process -Filter \"ProcessId=%d\" -ErrorAction SilentlyContinue; if($p){ $p.CommandLine }", pid))
+		out, err := cmd.Output()
+		return strings.TrimSpace(string(out)), err
+	}
+	out, err := exec.Command("ps", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
+	return strings.TrimSpace(string(out)), err
 }
 
 // monitorDaemon monitors the OpenClaw daemon process (fork pattern).
@@ -1501,6 +1637,8 @@ func (m *Manager) findOpenClawBin() string {
 	case "windows":
 		candidates = append(candidates,
 			`C:\Program Files\openclaw\openclaw.exe`,
+			`C:\ClawPanel\npm-global\openclaw.cmd`,
+			`C:\ClawPanel\npm-global\node_modules\.bin\openclaw.cmd`,
 			filepath.Join(home, "AppData", "Roaming", "npm", "openclaw.cmd"),
 		)
 	}

--- a/internal/process/manager_test.go
+++ b/internal/process/manager_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -53,6 +54,22 @@ func TestGatewayListeningIgnoresNonOpenClawListener(t *testing.T) {
 	mgr.gatewayProbe = func(_ string, _ string) bool { return false }
 	if mgr.GatewayListening() {
 		t.Fatalf("expected GatewayListening to ignore non-OpenClaw listener on port %d", port)
+	}
+}
+
+func TestLooksLikeOpenClawGatewayResponseRecognizesControlUI(t *testing.T) {
+	headers := http.Header{}
+	body := []byte("<!doctype html><title>OpenClaw Control</title><openclaw-app></openclaw-app>")
+	if !looksLikeOpenClawGatewayResponse("/", 200, headers, body) {
+		t.Fatalf("expected control UI HTML to be recognized as OpenClaw gateway")
+	}
+}
+
+func TestLooksLikeOpenClawGatewayResponseRecognizesHealthJSON(t *testing.T) {
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	body := []byte(`{"status":"live"}`)
+	if !looksLikeOpenClawGatewayResponse("/healthz", 200, headers, body) {
+		t.Fatalf("expected health JSON to be recognized as OpenClaw gateway")
 	}
 }
 

--- a/internal/taskman/taskman.go
+++ b/internal/taskman/taskman.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf16"
 
 	"github.com/zhaoxinyi02/ClawPanel/internal/websocket"
 )
@@ -244,9 +245,23 @@ func dedupeEnv(env []string) []string {
 // RunScript 运行脚本并实时推送输出（Windows 用 PowerShell，其他平台用 bash）
 func (m *Manager) RunScript(task *Task, script string) error {
 	if runtime.GOOS == "windows" {
-		return m.RunCommand(task, "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script)
+		return m.RunCommand(task, "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encodePowerShellCommand(strings.Join([]string{
+			`[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)`,
+			`[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)`,
+			`$OutputEncoding = [System.Text.UTF8Encoding]::new($false)`,
+			script,
+		}, "\n")))
 	}
 	return m.RunCommand(task, "bash", "-c", script)
+}
+
+func encodePowerShellCommand(script string) string {
+	utf16Data := utf16.Encode([]rune(script))
+	bytes := make([]byte, 0, len(utf16Data)*2)
+	for _, r := range utf16Data {
+		bytes = append(bytes, byte(r), byte(r>>8))
+	}
+	return base64.StdEncoding.EncodeToString(bytes)
 }
 
 // RunScriptWithSudo 使用 sudo 运行脚本


### PR DESCRIPTION
Keep panel-managed OpenClaw installs and gateway restarts resilient after panel updates so Windows deployments stop falling back to stale status checks, missing binary paths, and noisy PowerShell task failures.