### PR TITLE
Fix false NapCat login expiry on Windows

### DIFF
--- a/Debug/2026-03-09-napcat-login-expired-false-positive.md
+++ b/Debug/2026-03-09-napcat-login-expired-false-positive.md
@@ -1,0 +1,27 @@
+# 2026-03-09 NapCat 刚登录即提示失效
+
+## 问题
+
+- QQ（NapCat）刚完成登录后，面板很快又显示“登录已失效”。
+
+## 定位
+
+- 失效判断入口在 `internal/monitor/napcat.go` 的 `checkQQLoginStatus` / `doCheckQQLoginStatus`。
+- NapCat WebUI 鉴权失败时代码会走“重新取 token 再登录”的兜底逻辑。
+- 但这段兜底逻辑只从 Docker 容器内读取 `webui.json`，没有兼容 Windows NapCat Shell。
+- 因此在 Windows 上，一旦旧 credential 失效，重试分支拿不到新 token，会直接返回“未登录”，上层监控随后把状态打成 `login_expired`。
+- 同时，重试成功后 `GetQQLoginInfo` 仍继续使用旧的 `cred`，存在后续信息读取不一致的问题。
+
+## 修复
+
+- 提取统一的 `getNapCatWebUIToken`：
+  - Windows 优先读 NapCat 最新日志中的 WebUI token，再回退 `config/webui.json`
+  - Docker 继续读取容器内 `webui.json`
+- 初次认证和鉴权失败后的重试都改用这一个 token 读取入口。
+- 重试认证成功后同步更新当前请求使用的 `cred`，避免后续接口继续拿旧 credential。
+
+## 验证建议
+
+- 在 Windows 环境下重新登录 QQ，观察频道页 NapCat 状态是否仍会立刻跳成“登录已失效”。
+- 登录后等待 1~2 个监控周期，确认仍保持在线。
+- 若问题仍存在，再抓取 `napcat-status` websocket 推送和 NapCat WebUI 鉴权返回码继续排查。

--- a/internal/monitor/napcat.go
+++ b/internal/monitor/napcat.go
@@ -932,6 +932,41 @@ func checkQQLoginStatus(cfg *config.Config) (loggedIn bool, nickname string, qqI
 	return
 }
 
+func getNapCatWebUIToken(cfg *config.Config) string {
+	if runtime.GOOS == "windows" {
+		napcatDir := findNapCatShellDir(cfg)
+		if napcatDir == "" {
+			return ""
+		}
+		if tok := readTokenFromNapCatLogs(napcatDir); tok != "" {
+			return tok
+		}
+		webuiPath := filepath.Join(napcatDir, "config", "webui.json")
+		if data, err := os.ReadFile(webuiPath); err == nil {
+			var webui map[string]interface{}
+			if json.Unmarshal(data, &webui) == nil {
+				if t, ok := webui["token"].(string); ok && t != "" {
+					return t
+				}
+			}
+		}
+		return ""
+	}
+
+	out, err := dockerOutput("exec", "openclaw-qq", "cat", "/app/napcat/config/webui.json")
+	if err != nil {
+		return ""
+	}
+	var webui map[string]interface{}
+	if json.Unmarshal(out, &webui) != nil {
+		return ""
+	}
+	if t, ok := webui["token"].(string); ok && t != "" {
+		return t
+	}
+	return ""
+}
+
 // readTokenFromNapCatLogs finds NapCat's logs dir (walking up/down from bootmain dir)
 // and extracts the live token logged as "[WebUi] WebUi Token: <token>".
 func readTokenFromNapCatLogs(bootmainDir string) string {
@@ -1019,39 +1054,8 @@ func doCheckQQLoginStatus(cfg *config.Config) (loggedIn bool, nickname string, q
 	} else {
 		// Invalidate cache unconditionally so we always re-auth with the fresh token
 		cachedMonitorCred = ""
-		// Get WebUI token: from NapCat log (4.x uses random token per startup), or Docker
-		token := ""
-		if runtime.GOOS == "windows" {
-			napcatDir := findNapCatShellDir(cfg)
-			if napcatDir != "" {
-				// NapCat 4.x: read token from latest log file
-				if tok := readTokenFromNapCatLogs(napcatDir); tok != "" {
-					token = tok
-				}
-				// Fallback: webui.json in bootmain config
-				if token == "" {
-					webuiPath := filepath.Join(napcatDir, "config", "webui.json")
-					if data, err := os.ReadFile(webuiPath); err == nil {
-						var webui map[string]interface{}
-						if json.Unmarshal(data, &webui) == nil {
-							if t, ok := webui["token"].(string); ok && t != "" {
-								token = t
-							}
-						}
-					}
-				}
-			}
-		} else {
-			out, err := dockerOutput("exec", "openclaw-qq", "cat", "/app/napcat/config/webui.json")
-			if err == nil {
-				var webui map[string]interface{}
-				if json.Unmarshal(out, &webui) == nil {
-					if t, ok := webui["token"].(string); ok && t != "" {
-						token = t
-					}
-				}
-			}
-		}
+		// Get WebUI token: from NapCat log / webui.json / Docker config.
+		token := getNapCatWebUIToken(cfg)
 		if token == "" {
 			return false, "", ""
 		}
@@ -1103,16 +1107,7 @@ func doCheckQQLoginStatus(cfg *config.Config) (loggedIn bool, nickname string, q
 		cachedMonitorCred = ""
 		cachedMonitorCredTime = time.Time{}
 
-		freshToken := ""
-		out, err := dockerOutput("exec", "openclaw-qq", "cat", "/app/napcat/config/webui.json")
-		if err == nil {
-			var webui map[string]interface{}
-			if json.Unmarshal(out, &webui) == nil {
-				if t, ok := webui["token"].(string); ok && t != "" {
-					freshToken = t
-				}
-			}
-		}
+		freshToken := getNapCatWebUIToken(cfg)
 		if freshToken == "" {
 			return false, "", ""
 		}
@@ -1136,6 +1131,7 @@ func doCheckQQLoginStatus(cfg *config.Config) (loggedIn bool, nickname string, q
 		if freshCred == "" {
 			return false, "", ""
 		}
+		cred = freshCred
 		cachedMonitorCred = freshCred
 		cachedMonitorCredTime = time.Now()
 


### PR DESCRIPTION
## Summary
- fix the NapCat login monitor on Windows so WebUI credential refresh uses the same token lookup path as the initial login flow
- avoid marking QQ as login expired immediately after a successful login when the old credential becomes stale
- add a debug note documenting the false-positive expiry cause and the verification steps