### PR TITLE
macos在/User

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,6 +228,15 @@ func getDefaultOpenClawDir() string {
 				candidates = append(candidates, filepath.Join("/home", e.Name(), ".openclaw"))
 			}
 		}
+
+		if runtime.GOOS == "darwin" {
+			entries, _ := os.ReadDir("/Users")
+			for _, e := range entries {
+				if e.IsDir() {
+					candidates = append(candidates, filepath.Join("/Users", e.Name(), ".openclaw"))
+				}
+			}
+		}
 	}
 
 	// Return the first candidate that contains openclaw.json

--- a/internal/config/runtime_env.go
+++ b/internal/config/runtime_env.go
@@ -130,6 +130,16 @@ func candidateHomes() []string {
 			}
 		}
 	}
+	// macOS: root 运行时需扫描 /Users/*，否则 npm/二进制探测看不到真实用户的 nvm/fnm
+	if runtime.GOOS == "darwin" {
+		if entries, err := os.ReadDir("/Users"); err == nil {
+			for _, e := range entries {
+				if e.IsDir() && e.Name() != "Shared" {
+					homes = append(homes, filepath.Join("/Users", e.Name()))
+				}
+			}
+		}
+	}
 	return dedupeNonEmpty(homes)
 }
 


### PR DESCRIPTION
…ctories in getDefaultOpenClawDir and candidateHomes functions. This allows detection of user-specific .openclaw directories, improving compatibility with npm and binary detection for users on macOS.