### PR TITLE
Improve panel chat reply ordering

### DIFF
--- a/internal/handler/panel_chat.go
+++ b/internal/handler/panel_chat.go
@@ -281,16 +281,15 @@ func ensurePanelChatRuntime(cfg *config.Config, session panelChatSession) (state
 		return "", "", "", err
 	}
 	srcWorkspace := resolveAgentWorkspacePath(cfg, session.AgentID)
-	runtimeWorkspace := filepath.ToSlash(filepath.Join("openclaw-work", scopedAgentID))
 	dstWorkspace := filepath.Join(workDir, "openclaw-work", scopedAgentID)
-	if strings.TrimSpace(srcWorkspace) == "" {
-		if err = os.MkdirAll(dstWorkspace, 0o755); err != nil {
+	if strings.TrimSpace(srcWorkspace) != "" {
+		if err = syncDirPreferSource(srcWorkspace, dstWorkspace); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", "", "", err
 		}
-	} else {
-		runtimeWorkspace = filepath.ToSlash(srcWorkspace)
+	} else if err = os.MkdirAll(dstWorkspace, 0o755); err != nil {
+		return "", "", "", err
 	}
-	if err = rewritePanelChatRuntimeConfig(cfg, sourceConfigPath, configPath, session, runtimeWorkspace); err != nil {
+	if err = rewritePanelChatRuntimeConfig(cfg, sourceConfigPath, configPath, session, ""); err != nil {
 		return "", "", "", err
 	}
 	return stateDir, configPath, workDir, nil
@@ -395,7 +394,7 @@ func copyDirWithoutSessions(src, dst string) error {
 	})
 }
 
-func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigPath string, session panelChatSession, runtimeWorkspace string) error {
+func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigPath string, session panelChatSession, configuredWorkspace string) error {
 	data, err := os.ReadFile(srcConfigPath)
 	if err != nil {
 		return err
@@ -417,24 +416,24 @@ func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigP
 		}
 		scopedID := panelChatScopedAgentID(session.ID, session.AgentID)
 		cloned["id"] = scopedID
-		if strings.TrimSpace(runtimeWorkspace) != "" {
-			cloned["workspace"] = filepath.ToSlash(runtimeWorkspace)
-		} else {
-			cloned["workspace"] = filepath.ToSlash(filepath.Join("openclaw-work", scopedID))
+		workspace := strings.TrimSpace(configuredWorkspace)
+		if workspace == "" {
+			workspace = filepath.ToSlash(filepath.Join("openclaw-work", scopedID))
 		}
+		cloned["workspace"] = workspace
 		cloned["default"] = true
 		newList = append(newList, cloned)
 		break
 	}
 	if len(newList) == 0 && strings.TrimSpace(session.AgentID) != "" {
 		scopedID := panelChatScopedAgentID(session.ID, session.AgentID)
-		workspace := strings.TrimSpace(runtimeWorkspace)
+		workspace := strings.TrimSpace(configuredWorkspace)
 		if workspace == "" {
 			workspace = filepath.ToSlash(filepath.Join("openclaw-work", scopedID))
 		}
 		newList = append(newList, map[string]interface{}{
 			"id":        scopedID,
-			"workspace": filepath.ToSlash(workspace),
+			"workspace": workspace,
 			"default":   true,
 		})
 	}
@@ -611,6 +610,15 @@ func loadPanelChatParticipants(db *sql.DB, cfg *config.Config, session panelChat
 			OpenClawSessionID: item.OpenClawSessionID,
 		})
 	}
+	sort.SliceStable(views, func(i, j int) bool {
+		if views[i].IsSummary != views[j].IsSummary {
+			return !views[i].IsSummary
+		}
+		if views[i].OrderIndex != views[j].OrderIndex {
+			return views[i].OrderIndex < views[j].OrderIndex
+		}
+		return views[i].AgentID < views[j].AgentID
+	})
 	if len(views) == 0 && strings.TrimSpace(session.AgentID) != "" {
 		views = append(views, panelChatParticipantView{AgentID: session.AgentID, Name: nameMap[session.AgentID], RoleType: "assistant", OrderIndex: 0, AutoReply: true, Enabled: true})
 	}
@@ -722,6 +730,10 @@ func readPanelChatMessages(cfg *config.Config, session panelChatSession) ([]map[
 		return nil, err
 	}
 
+	return readPanelChatTranscript(filePath, session.AgentID)
+}
+
+func readPanelChatTranscript(filePath, agentID string) ([]map[string]interface{}, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -773,7 +785,7 @@ func readPanelChatMessages(cfg *config.Config, session panelChatSession) ([]map[
 			"timestamp":  ts,
 		}
 		if role == "assistant" {
-			message["agentId"] = session.AgentID
+			message["agentId"] = agentID
 			message["messageType"] = "chat"
 		}
 		if len(images) > 0 {
@@ -938,6 +950,21 @@ func runPanelChatMessage(ctx context.Context, cfg *config.Config, session panelC
 	return strings.Join(parts, "\n\n"), strings.TrimSpace(result.Result.Meta.AgentMeta.SessionID), nil
 }
 
+func runPanelChatMessageWithRecovery(ctx context.Context, cfg *config.Config, session panelChatSession, message string) (string, string, []map[string]interface{}, error) {
+	reply, actualSessionID, err := runPanelChatMessage(ctx, cfg, session, message)
+	transcript, historyErr := readPanelChatTranscript(panelChatRuntimeSessionFile(cfg, session), session.AgentID)
+	if historyErr == nil && (strings.TrimSpace(reply) == "" || err != nil) {
+		recovered := extractLatestAssistantReply(transcript, message)
+		if strings.TrimSpace(recovered) != "" {
+			reply = recovered
+			if errors.Is(err, errPanelChatTimeout) {
+				err = nil
+			}
+		}
+	}
+	return reply, actualSessionID, transcript, err
+}
+
 func buildGroupChatPrompt(agentName string, participant panelChatParticipantView, transcript []map[string]interface{}, latestUserMessage string) string {
 	lines := []string{
 		fmt.Sprintf("你正在参与一个多 AI 角色群聊。你的身份是：%s。", strings.TrimSpace(agentName)),
@@ -996,6 +1023,7 @@ func executeGroupPanelChat(ctx context.Context, cfg *config.Config, session pane
 		"timestamp":   userTimestamp,
 	}
 	messages = append(messages, userEntry)
+	_ = savePanelChatMessages(cfg, session.ID, messages)
 	lastReply := ""
 	for _, participant := range participants {
 		if !participant.Enabled || !participant.AutoReply {
@@ -1018,18 +1046,7 @@ func executeGroupPanelChat(ctx context.Context, cfg *config.Config, session pane
 		if runtimeSession.OpenClawSessionID == "" {
 			runtimeSession.OpenClawSessionID = fmt.Sprintf("%s-%s", session.ID, participant.AgentID)
 		}
-		reply, actualSessionID, err := runPanelChatMessage(ctx, cfg, runtimeSession, prompt)
-		if strings.TrimSpace(reply) == "" || err != nil {
-			if rawMessages, historyErr := readSessionMessages(panelChatRuntimeSessionFile(cfg, runtimeSession), 200); historyErr == nil {
-				recovered := extractLatestAssistantReply(rawMessages, prompt)
-				if strings.TrimSpace(recovered) != "" {
-					reply = recovered
-					if errors.Is(err, errPanelChatTimeout) {
-						err = nil
-					}
-				}
-			}
-		}
+		reply, actualSessionID, _, err := runPanelChatMessageWithRecovery(ctx, cfg, runtimeSession, prompt)
 		if strings.TrimSpace(actualSessionID) != "" {
 			sessionIDs[participant.AgentID] = strings.TrimSpace(actualSessionID)
 		}
@@ -1054,6 +1071,12 @@ func executeGroupPanelChat(ctx context.Context, cfg *config.Config, session pane
 			"messageType": messageType,
 			"content":     reply,
 			"timestamp":   time.Now().UTC().Format(time.RFC3339),
+		})
+		_ = savePanelChatMessages(cfg, session.ID, messages)
+		_, _ = updatePanelChatSessionState(cfg, session.ID, func(item *panelChatSession) {
+			item.UpdatedAt = time.Now().UnixMilli()
+			item.MessageCount = len(messages)
+			item.LastMessage = strings.TrimSpace(userMessage)
 		})
 	}
 	return messages, lastReply, sessionIDs, nil
@@ -1402,9 +1425,16 @@ func SendPanelChatMessage(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		if session.ChatType == "group" || len(participants) > 1 {
 			existingMessages, reply, participantSessionUpdates, runErr = executeGroupPanelChat(c.Request.Context(), cfg, *session, participants, existingMessages, strings.TrimSpace(req.Message))
 		} else {
-			reply, actualSessionID, runErr = runPanelChatMessage(c.Request.Context(), cfg, *session, strings.TrimSpace(req.Message))
+			var rawMessages []map[string]interface{}
+			reply, actualSessionID, rawMessages, runErr = runPanelChatMessageWithRecovery(c.Request.Context(), cfg, *session, strings.TrimSpace(req.Message))
 			if strings.TrimSpace(actualSessionID) != "" {
 				session.OpenClawSessionID = strings.TrimSpace(actualSessionID)
+			}
+			if len(rawMessages) > 0 {
+				latestExchange := extractLatestPanelChatExchange(rawMessages, strings.TrimSpace(req.Message))
+				if len(latestExchange) > 0 {
+					existingMessages = mergePanelChatTranscripts(existingMessages, latestExchange)
+				}
 			}
 		}
 		_, _ = updatePanelChatSessionState(cfg, session.ID, func(item *panelChatSession) {
@@ -1416,13 +1446,7 @@ func SendPanelChatMessage(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			}
 		})
 		if session.ChatType != "group" && len(participants) <= 1 {
-			rawMessages, historyErr := readSessionMessages(panelChatRuntimeSessionFile(cfg, *session), 400)
-			if historyErr == nil {
-				latestExchange := extractLatestPanelChatExchange(rawMessages, strings.TrimSpace(req.Message))
-				if len(latestExchange) > 0 {
-					existingMessages = mergePanelChatTranscripts(existingMessages, latestExchange)
-				}
-			}
+			// transcript merge already handled in direct path via runPanelChatMessageWithRecovery
 		}
 		if len(existingMessages) == 0 && strings.TrimSpace(reply) != "" {
 			userTime := time.Now().UTC()

--- a/web/src/pages/PanelChat.tsx
+++ b/web/src/pages/PanelChat.tsx
@@ -120,7 +120,6 @@ export default function PanelChat() {
   const abortControllerRef = useRef<AbortController | null>(null);
   const abortMarkerHandledRef = useRef<Record<string, boolean>>({});
   const activeRequestIdRef = useRef(0);
-  const composingRef = useRef(false);
 
   const text = useMemo(() => {
     if (locale === 'en') {
@@ -335,6 +334,53 @@ export default function PanelChat() {
       }
     }
   }, [draftMode, selectedSession, visibleSessions]);
+
+  useEffect(() => {
+    const sessionId = processingSessionId || selectedId;
+    if (!sessionId) return;
+    const session = sessions.find(item => item.id === sessionId);
+    const stillProcessing = sessionId === processingSessionId || !!session?.processing;
+    if (!stillProcessing) return;
+
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const [detailRes, listRes] = await Promise.all([
+          api.getPanelChatSessionDetail(sessionId),
+          api.getPanelChatSessions(),
+        ]);
+
+        if (cancelled) return;
+
+        if (detailRes?.ok && selectedIdRef.current === sessionId) {
+          setMessages(Array.isArray(detailRes.messages) ? detailRes.messages : []);
+          setParticipants(Array.isArray(detailRes.participants) ? detailRes.participants : []);
+        }
+
+        if (listRes?.ok) {
+          const next = Array.isArray(listRes.sessions) ? listRes.sessions : [];
+          setSessions(next);
+          const updated = next.find((item: PanelChatSession) => item.id === sessionId);
+          if (!updated?.processing && processingSessionId === sessionId) {
+            setProcessingSessionId('');
+            setPendingUserMessage(null);
+          }
+        }
+      } catch {
+        // Ignore transient polling failures while a session is still running.
+      }
+    };
+
+    void tick();
+    const timer = window.setInterval(() => {
+      void tick();
+    }, 1200);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [processingSessionId, selectedId, sessions]);
 
   const toggleDraftAgent = useCallback((agentId: string) => {
     setSelectedAgentIds(current => {
@@ -835,12 +881,7 @@ export default function PanelChat() {
               <textarea
                 value={input}
                 onChange={event => setInput(event.target.value)}
-                onCompositionStart={() => { composingRef.current = true; }}
-                onCompositionEnd={() => { composingRef.current = false; }}
                 onKeyDown={event => {
-                  if (event.nativeEvent.isComposing || composingRef.current || (event as unknown as { keyCode?: number }).keyCode === 229) {
-                    return;
-                  }
                   if (event.key === 'Enter' && !event.shiftKey) {
                     event.preventDefault();
                     void handleSend();


### PR DESCRIPTION
## Summary



- persist group chat replies incrementally so completed agent messages appear earlier

- poll panel chat detail during processing so replies render before the full run completes

- move summary execution after worker agents for a more natural reply order