### PR TITLE
fix: remove legacy keys from panel chat config

### DIFF
--- a/internal/handler/panel_chat.go
+++ b/internal/handler/panel_chat.go
@@ -442,6 +442,8 @@ func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigP
 	obj["agents"] = agentsMap
 	delete(obj, "channels")
 	delete(obj, "plugins")
+	delete(obj, "model")
+	delete(obj, "sessionDir")
 	encoded, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		return err

--- a/internal/handler/panel_chat_test.go
+++ b/internal/handler/panel_chat_test.go
@@ -279,6 +279,41 @@ func TestRewritePanelChatRuntimeConfigSynthesizesImplicitAgent(t *testing.T) {
 	}
 }
 
+func TestRewritePanelChatRuntimeConfigStripsLegacyRootKeys(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.Config{
+		DataDir:     filepath.Join(root, "data"),
+		OpenClawDir: filepath.Join(root, ".openclaw"),
+		Edition:     "pro",
+	}
+	if err := os.MkdirAll(filepath.Join(cfg.OpenClawDir, "agents", "main", "agent"), 0o755); err != nil {
+		t.Fatalf("mkdir agent dir failed: %v", err)
+	}
+	src := filepath.Join(root, "src-openclaw.json")
+	dst := filepath.Join(root, "dst-openclaw.json")
+	if err := os.WriteFile(src, []byte(`{"agents":{"defaults":{}},"model":"claude-3-5-sonnet","sessionDir":"/tmp/sessions"}`), 0o644); err != nil {
+		t.Fatalf("write src config failed: %v", err)
+	}
+	session := panelChatSession{ID: "panel-3", AgentID: "main"}
+	if err := rewritePanelChatRuntimeConfig(cfg, src, dst, session, ""); err != nil {
+		t.Fatalf("rewritePanelChatRuntimeConfig failed: %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst config failed: %v", err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unmarshal dst config failed: %v", err)
+	}
+	if _, ok := obj["model"]; ok {
+		t.Fatalf("expected panel chat runtime config to omit model, got %#v", obj["model"])
+	}
+	if _, ok := obj["sessionDir"]; ok {
+		t.Fatalf("expected panel chat runtime config to omit sessionDir, got %#v", obj["sessionDir"])
+	}
+}
+
 func TestRewritePanelChatRuntimeConfigPreservesConfiguredWorkspace(t *testing.T) {
 	root := t.TempDir()
 	workspace := filepath.Join(root, "workspaces", "writer")


### PR DESCRIPTION
## 变更说明

Fixes #131. The panel chat config rewrite was keeping legacy root-level keys ("model" and "sessionDir") that shouldn't be there, causing both Lite and Pro to fail. These get stripped now, same as we do for "channels" and "plugins". Added a test to verify.

## 变更类型

- [x] 缺陷修复
- [ ] 新功能
- [ ] 文档改进
- [ ] 重构
- [ ] 测试补充
- [ ] CI / 发布流程调整

## 影响范围

- [ ] 前端
- [x] 后端
- [ ] 安装 / 更新脚本
- [ ] 文档 / Wiki
- [ ] 插件 / 通道

## 验证方式

The new test `TestRewritePanelChatRuntimeConfigStripsLegacyRootKeys` verifies that "model" and "sessionDir" are properly removed from the rewritten config.

## 风险与兼容性

- [x] 无明显破坏性变更
- [ ] 存在兼容性影响，已在说明中写明

## 补充信息

N/A