### PR TITLE
fix(feishu): normalize channel config for OpenClaw 4.11 schema

### DIFF
--- a/internal/handler/openclaw.go
+++ b/internal/handler/openclaw.go
@@ -940,11 +940,181 @@ func normalizeFeishuRequireMention(raw interface{}) (bool, bool, error) {
 	}
 }
 
+func normalizeFeishuSwitchMode(raw interface{}, field string) (string, bool, error) {
+	switch v := raw.(type) {
+	case nil:
+		return "", false, nil
+	case bool:
+		if v {
+			return "enabled", true, nil
+		}
+		return "disabled", true, nil
+	case float64:
+		if v == 1 {
+			return "enabled", true, nil
+		}
+		if v == 0 {
+			return "disabled", true, nil
+		}
+	case int:
+		if v == 1 {
+			return "enabled", true, nil
+		}
+		if v == 0 {
+			return "disabled", true, nil
+		}
+	case int64:
+		if v == 1 {
+			return "enabled", true, nil
+		}
+		if v == 0 {
+			return "disabled", true, nil
+		}
+	case json.Number:
+		if parsed, err := v.Int64(); err == nil {
+			if parsed == 1 {
+				return "enabled", true, nil
+			}
+			if parsed == 0 {
+				return "disabled", true, nil
+			}
+		}
+	case string:
+		trimmed := strings.TrimSpace(strings.ToLower(v))
+		switch trimmed {
+		case "":
+			return "", false, nil
+		case "enabled", "true", "1", "on":
+			return "enabled", true, nil
+		case "disabled", "false", "0", "off":
+			return "disabled", true, nil
+		}
+	}
+	return "", false, fmt.Errorf("%s 仅支持 enabled/disabled", field)
+}
+
+func normalizePositiveInt(raw interface{}) (int64, bool) {
+	switch v := raw.(type) {
+	case int:
+		if v > 0 {
+			return int64(v), true
+		}
+	case int64:
+		if v > 0 {
+			return v, true
+		}
+	case float64:
+		if v > 0 && float64(int64(v)) == v {
+			return int64(v), true
+		}
+	case json.Number:
+		if parsed, err := v.Int64(); err == nil && parsed > 0 {
+			return parsed, true
+		}
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return 0, false
+		}
+		if parsed, err := strconv.ParseInt(trimmed, 10, 64); err == nil && parsed > 0 {
+			return parsed, true
+		}
+	}
+	return 0, false
+}
+
+func normalizeFeishuDynamicAgentCreation(raw interface{}) (map[string]interface{}, bool, error) {
+	switch v := raw.(type) {
+	case nil:
+		return nil, false, nil
+	case bool:
+		return map[string]interface{}{"enabled": v}, true, nil
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return nil, false, nil
+		}
+		parsed, err := strconv.ParseBool(trimmed)
+		if err != nil {
+			return nil, false, fmt.Errorf("dynamicAgentCreation 仅支持 object 或 true/false")
+		}
+		return map[string]interface{}{"enabled": parsed}, true, nil
+	case map[string]interface{}:
+		next := map[string]interface{}{}
+		if enabled, ok := normalizeOptionalBool(v["enabled"]); ok {
+			next["enabled"] = enabled
+		}
+		if ws := strings.TrimSpace(toString(v["workspaceTemplate"])); ws != "" {
+			next["workspaceTemplate"] = ws
+		}
+		if dir := strings.TrimSpace(toString(v["agentDirTemplate"])); dir != "" {
+			next["agentDirTemplate"] = dir
+		}
+		if maxAgents, ok := normalizePositiveInt(v["maxAgents"]); ok {
+			next["maxAgents"] = maxAgents
+		}
+		if len(next) == 0 {
+			return nil, false, nil
+		}
+		return next, true, nil
+	default:
+		return nil, false, fmt.Errorf("dynamicAgentCreation 仅支持 object 或 true/false")
+	}
+}
+
 func normalizeFeishuChannelConfigInPlace(body map[string]interface{}) error {
 	if body == nil {
 		return nil
 	}
+	legacyThreadSession, hasLegacyThreadSession := body["threadSession"]
 	delete(body, "dmScope")
+	delete(body, "botName")
+
+	if raw, exists := body["replyInThread"]; exists {
+		normalized, keep, err := normalizeFeishuSwitchMode(raw, "replyInThread")
+		if err != nil {
+			return err
+		}
+		if keep {
+			body["replyInThread"] = normalized
+		} else {
+			delete(body, "replyInThread")
+		}
+	}
+
+	if raw, exists := body["topicSessionMode"]; exists {
+		normalized, keep, err := normalizeFeishuSwitchMode(raw, "topicSessionMode")
+		if err != nil {
+			return err
+		}
+		if keep {
+			body["topicSessionMode"] = normalized
+		} else {
+			delete(body, "topicSessionMode")
+		}
+	}
+	if _, exists := body["topicSessionMode"]; !exists && hasLegacyThreadSession {
+		normalized, keep, err := normalizeFeishuSwitchMode(legacyThreadSession, "topicSessionMode")
+		if err != nil {
+			return err
+		}
+		if keep {
+			body["topicSessionMode"] = normalized
+		}
+	}
+	delete(body, "threadSession")
+
+	if raw, exists := body["dynamicAgentCreation"]; exists {
+		normalized, keep, err := normalizeFeishuDynamicAgentCreation(raw)
+		if err != nil {
+			return err
+		}
+		if keep {
+			body["dynamicAgentCreation"] = normalized
+		} else {
+			delete(body, "dynamicAgentCreation")
+		}
+	}
 
 	if raw, exists := body["requireMention"]; exists {
 		normalized, keep, err := normalizeFeishuRequireMention(raw)

--- a/internal/handler/openclaw_test.go
+++ b/internal/handler/openclaw_test.go
@@ -1017,6 +1017,42 @@ func TestNormalizeFeishuChannelConfigToleratesLegacyRequireMentionOpen(t *testin
 	}
 }
 
+func TestNormalizeFeishuChannelConfigNormalizesThreadAndDynamicFields(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"threadSession":        true,
+		"replyInThread":        true,
+		"dynamicAgentCreation": false,
+		"botName":              "legacy-top-level",
+		"requireMention":       "true",
+		"defaultAccount":       "default",
+		"accounts":             map[string]interface{}{"default": map[string]interface{}{"appId": "cli_x", "appSecret": "sec_x"}},
+	}
+
+	got := normalizeFeishuChannelConfig(input)
+
+	if got["topicSessionMode"] != "enabled" {
+		t.Fatalf("expected threadSession=true to migrate to topicSessionMode=enabled, got %#v", got["topicSessionMode"])
+	}
+	if got["replyInThread"] != "enabled" {
+		t.Fatalf("expected replyInThread=true to normalize to enabled, got %#v", got["replyInThread"])
+	}
+	dynamicCfg, _ := got["dynamicAgentCreation"].(map[string]interface{})
+	if dynamicCfg == nil {
+		t.Fatalf("expected dynamicAgentCreation bool to normalize to object, got %#v", got["dynamicAgentCreation"])
+	}
+	if enabled, ok := dynamicCfg["enabled"].(bool); !ok || enabled {
+		t.Fatalf("expected dynamicAgentCreation.enabled=false, got %#v", dynamicCfg["enabled"])
+	}
+	if _, exists := got["threadSession"]; exists {
+		t.Fatalf("expected legacy threadSession to be removed, got %#v", got["threadSession"])
+	}
+	if _, exists := got["botName"]; exists {
+		t.Fatalf("expected top-level botName to be removed, got %#v", got["botName"])
+	}
+}
+
 func TestNormalizeWeComChannelConfigCallbackMode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fix #129: ClawPanel writes channels.feishu config incompatible with OpenClaw 4.11 schema

## Changes
- Normalize replyInThread to enabled/disabled string values (was accepting bool/number)
- Normalize dynamicAgentCreation to object (compatible with bool/string input)  
- Migrate threadSession to topicSessionMode
- Clean up legacy fields (dmScope, threadSession, botName top-level)

## Testing
- Unit tests pass for all normalizeFeishuChannelConfig test cases