### PR TITLE
Remove sessionDir from panel chat runtime config

### DIFF
--- a/internal/handler/panel_chat.go
+++ b/internal/handler/panel_chat.go
@@ -442,6 +442,7 @@ func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigP
 	obj["agents"] = agentsMap
 	delete(obj, "channels")
 	delete(obj, "plugins")
+	delete(obj, "sessionDir")
 	encoded, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		return err

--- a/internal/handler/panel_chat_test.go
+++ b/internal/handler/panel_chat_test.go
@@ -247,7 +247,7 @@ func TestRewritePanelChatRuntimeConfigSynthesizesImplicitAgent(t *testing.T) {
 	}
 	src := filepath.Join(root, "src-openclaw.json")
 	dst := filepath.Join(root, "dst-openclaw.json")
-	if err := os.WriteFile(src, []byte(`{"agents":{"defaults":{"workspace":"/tmp/work"}},"models":{"providers":{}},"channels":{"qqbot":{"appId":"123"}},"plugins":{"entries":{"qqbot":{"enabled":true}}}}`), 0o644); err != nil {
+	if err := os.WriteFile(src, []byte(`{"agents":{"defaults":{"workspace":"/tmp/work"}},"models":{"providers":{}},"channels":{"qqbot":{"appId":"123"}},"plugins":{"entries":{"qqbot":{"enabled":true}}},"sessionDir":"/some/path/sessions"}`), 0o644); err != nil {
 		t.Fatalf("write src config failed: %v", err)
 	}
 	session := panelChatSession{ID: "panel-1", AgentID: "main"}
@@ -276,6 +276,9 @@ func TestRewritePanelChatRuntimeConfigSynthesizesImplicitAgent(t *testing.T) {
 	}
 	if _, ok := obj["plugins"]; ok {
 		t.Fatalf("expected panel chat runtime config to omit plugins, got %#v", obj["plugins"])
+	}
+	if _, ok := obj["sessionDir"]; ok {
+		t.Fatalf("expected panel chat runtime config to omit sessionDir, got %#v", obj["sessionDir"])
 	}
 }
 


### PR DESCRIPTION
## 变更描述
修了配置重写时没删除 sessionDir 的问题（#137）。现在把 sessionDir 从输出配置中删除，和 channels、plugins 处理一样。

## 变更类型
- [x] bugfix

## 影响范围
- [x] 后端

## 验证方式
更新测试用例，验证 sessionDir 被正确删除。

## 破坏性变更
无