### PR TITLE
feat: unify Hermes panel management and preserve Lite data

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,10 +101,14 @@ func Load() (*Config, error) {
 	cfg.Edition = normalizeEdition(cfg.Edition)
 	if cfg.IsLiteEdition() {
 		cfg.Port = DefaultPort
-		cfg.DataDir = filepath.Join(cfg.InstallRoot(), "data")
-		cfg.OpenClawDir = cfg.BundledOpenClawConfigDir()
+		if v := strings.TrimSpace(os.Getenv("CLAWPANEL_DATA")); v != "" {
+			cfg.DataDir = v
+		} else if strings.TrimSpace(cfg.DataDir) == "" {
+			cfg.DataDir = filepath.Join(cfg.InstallRoot(), "data")
+		}
+		cfg.OpenClawDir = filepath.Join(cfg.DataDir, "openclaw-config")
 		cfg.OpenClawApp = cfg.BundledOpenClawAppDir()
-		cfg.OpenClawWork = cfg.BundledOpenClawWorkDir()
+		cfg.OpenClawWork = filepath.Join(cfg.DataDir, "openclaw-work")
 	}
 
 	// 路径校验：
@@ -203,10 +207,16 @@ func (c *Config) BundledRuntimeRoot() string {
 }
 
 func (c *Config) BundledOpenClawConfigDir() string {
+	if c != nil && strings.TrimSpace(c.DataDir) != "" {
+		return filepath.Join(c.DataDir, "openclaw-config")
+	}
 	return filepath.Join(c.InstallRoot(), "data", "openclaw-config")
 }
 
 func (c *Config) BundledOpenClawWorkDir() string {
+	if c != nil && strings.TrimSpace(c.DataDir) != "" {
+		return filepath.Join(c.DataDir, "openclaw-work")
+	}
 	return filepath.Join(c.InstallRoot(), "data", "openclaw-work")
 }
 

--- a/internal/handler/hermes.go
+++ b/internal/handler/hermes.go
@@ -40,6 +40,7 @@ func firstHermesConfig(cfgs ...*config.Config) *config.Config {
 
 var hermesPlatformSpecs = []hermesPlatformSpec{
 	{ID: "telegram", Label: "Telegram", ConfigPaths: []string{"gateway.telegram"}, RequiredEnv: []string{"TELEGRAM_BOT_TOKEN"}, OptionalEnv: []string{"TELEGRAM_ALLOWED_USERS", "TELEGRAM_HOME_CHAT"}},
+	{ID: "qqbot", Label: "QQ Bot", ConfigPaths: []string{"platforms.qq", "platforms.qqbot", "gateway.qqbot"}, RequiredEnv: []string{"QQ_APP_ID", "QQ_CLIENT_SECRET"}, OptionalEnv: []string{"QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME", "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL"}},
 	{ID: "discord", Label: "Discord", ConfigPaths: []string{"gateway.discord"}, RequiredEnv: []string{"DISCORD_BOT_TOKEN"}, OptionalEnv: []string{"DISCORD_ALLOWED_USERS", "DISCORD_HOME_CHANNEL"}},
 	{ID: "slack", Label: "Slack", ConfigPaths: []string{"gateway.slack"}, RequiredEnv: []string{"SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"}, OptionalEnv: []string{"SLACK_ALLOWED_USERS", "SLACK_HOME_CHANNEL"}},
 	{ID: "weixin", Label: "Weixin / WeChat", ConfigPaths: []string{"gateway.weixin"}, RequiredEnv: []string{"WEIXIN_ACCOUNT_ID", "WEIXIN_TOKEN"}, OptionalEnv: []string{"WEIXIN_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL_NAME", "WEIXIN_ALLOWED_USERS"}},
@@ -226,6 +227,21 @@ type HermesPlatformDetail struct {
 	Status      HermesPlatformStatus   `json:"status"`
 	Config      map[string]interface{} `json:"config"`
 	Environment map[string]string      `json:"environment"`
+	Fields      []HermesPlatformField  `json:"fields,omitempty"`
+}
+
+type HermesPlatformField struct {
+	Key         string   `json:"key"`
+	Label       string   `json:"label"`
+	Type        string   `json:"type"`
+	Section     string   `json:"section,omitempty"`
+	EnvVar      bool     `json:"envVar,omitempty"`
+	Required    bool     `json:"required,omitempty"`
+	Help        string   `json:"help,omitempty"`
+	Placeholder string   `json:"placeholder,omitempty"`
+	Options     []string `json:"options,omitempty"`
+	ValueFormat string   `json:"valueFormat,omitempty"`
+	Rows        int      `json:"rows,omitempty"`
 }
 
 type HermesOverview struct {
@@ -360,6 +376,75 @@ type hermesPlatformSpec struct {
 	ConfigPaths []string
 	RequiredEnv []string
 	OptionalEnv []string
+}
+
+func humanizeHermesEnvKey(key string) string {
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(key)), "_")
+	for i, part := range parts {
+		switch part {
+		case "id":
+			parts[i] = "ID"
+		case "url":
+			parts[i] = "URL"
+		case "api":
+			parts[i] = "API"
+		case "stt":
+			parts[i] = "STT"
+		case "qq":
+			parts[i] = "QQ"
+		default:
+			if part == "" {
+				continue
+			}
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildHermesPlatformEnvField(key string, required bool) HermesPlatformField {
+	upper := strings.ToUpper(strings.TrimSpace(key))
+	field := HermesPlatformField{
+		Key:      upper,
+		Label:    humanizeHermesEnvKey(upper),
+		Type:     "text",
+		Section:  "advanced",
+		EnvVar:   true,
+		Required: required,
+	}
+
+	switch {
+	case strings.Contains(upper, "TOKEN") || strings.Contains(upper, "SECRET") || strings.Contains(upper, "PASSWORD") || strings.Contains(upper, "API_KEY"):
+		field.Type = "password"
+	case strings.HasSuffix(upper, "_PORT"):
+		field.Type = "number"
+	case strings.HasSuffix(upper, "_ENABLED") || strings.Contains(upper, "ALLOW_ALL") || strings.Contains(upper, "MARKDOWN_SUPPORT"):
+		field.Type = "toggle"
+	case strings.Contains(upper, "ALLOWED_USERS") || strings.Contains(upper, "ALLOW_FROM") || strings.Contains(upper, "FALLBACK_IPS"):
+		field.Type = "textarea"
+		field.Rows = 3
+		field.ValueFormat = "stringArray"
+	}
+
+	switch {
+	case strings.Contains(upper, "APP_ID") || strings.Contains(upper, "CLIENT_SECRET") || strings.Contains(upper, "BOT_TOKEN") || strings.Contains(upper, "BOT_ID"):
+		field.Section = "bot"
+	case strings.Contains(upper, "HOME_") || strings.Contains(upper, "ALLOWED_") || strings.Contains(upper, "ALLOW_ALL"):
+		field.Section = "platform"
+	}
+
+	return field
+}
+
+func buildHermesPlatformFields(spec *hermesPlatformSpec) []HermesPlatformField {
+	fields := make([]HermesPlatformField, 0, len(spec.RequiredEnv)+len(spec.OptionalEnv))
+	for _, key := range spec.RequiredEnv {
+		fields = append(fields, buildHermesPlatformEnvField(key, true))
+	}
+	for _, key := range spec.OptionalEnv {
+		fields = append(fields, buildHermesPlatformEnvField(key, false))
+	}
+	return fields
 }
 
 func hermesHomeDir(cfgs ...*config.Config) string {
@@ -966,6 +1051,26 @@ func detectHermesWarnings(status HermesStatus, data HermesDataSummary) []string 
 	return warnings
 }
 
+func detectHermesOverviewWarnings(status HermesStatus) []string {
+	warnings := make([]string, 0, 6)
+	switch {
+	case !status.Installed:
+		warnings = append(warnings, "Hermes 未安装")
+	case !status.Configured:
+		warnings = append(warnings, "Hermes 已安装但尚未初始化配置")
+	}
+	if status.Installed && !status.Running {
+		warnings = append(warnings, "Hermes 当前未运行")
+	}
+	if status.Installed && status.Running && !status.GatewayRunning {
+		warnings = append(warnings, "Hermes 主进程已运行，但未检测到消息网关")
+	}
+	if status.Installed && strings.TrimSpace(status.PythonVersion) == "" {
+		warnings = append(warnings, "未检测到 Python 运行时")
+	}
+	return warnings
+}
+
 func checkHermesState(status HermesStatus, configState HermesConfigState, data HermesDataSummary, platforms HermesPlatformsSnapshot, doctor *HermesDoctorSnapshot) ([]ConfigIssue, int) {
 	issues := make([]ConfigIssue, 0, 16)
 	checked := 0
@@ -1083,7 +1188,7 @@ func checkHermesState(status HermesStatus, configState HermesConfigState, data H
 
 	for _, platform := range platforms.Platforms {
 		checked++
-		if platform.Configured && len(platform.MissingEnvKeys) > 0 {
+		if platform.Enabled && len(platform.MissingEnvKeys) > 0 {
 			issues = append(issues, ConfigIssue{
 				ID:          "hermes-platform-" + platform.ID + "-missing-env",
 				Severity:    "error",
@@ -1095,7 +1200,7 @@ func checkHermesState(status HermesStatus, configState HermesConfigState, data H
 			})
 		}
 		checked++
-		if platform.RuntimeStatus == "error" && platform.LastError != "" {
+		if platform.Enabled && platform.RuntimeStatus == "error" && platform.LastError != "" {
 			issues = append(issues, ConfigIssue{
 				ID:          "hermes-platform-" + platform.ID + "-runtime-error",
 				Severity:    "warning",
@@ -1203,12 +1308,20 @@ func detectHermesPlatforms(configState HermesConfigState) HermesPlatformsSnapsho
 
 		configConfigured := false
 		configEnabled := false
+		explicitEnabledSet := false
+		explicitEnabledValue := false
 		for _, path := range spec.ConfigPaths {
 			value := hermesNestedValue(yamlMap, path)
 			if value == nil {
 				continue
 			}
 			configConfigured = true
+			if _, ok := value.(bool); ok {
+				explicitEnabledSet = true
+				explicitEnabledValue = truthyHermesValue(value)
+				configEnabled = explicitEnabledValue
+				break
+			}
 			if truthyHermesValue(value) {
 				configEnabled = true
 				break
@@ -1217,6 +1330,8 @@ func detectHermesPlatforms(configState HermesConfigState) HermesPlatformsSnapsho
 				if len(valueMap) > 0 {
 					configEnabled = true
 					if enabledRaw, exists := valueMap["enabled"]; exists {
+						explicitEnabledSet = true
+						explicitEnabledValue = truthyHermesValue(enabledRaw)
 						configEnabled = truthyHermesValue(enabledRaw)
 					}
 					break
@@ -1225,13 +1340,17 @@ func detectHermesPlatforms(configState HermesConfigState) HermesPlatformsSnapsho
 		}
 
 		item.Configured = configConfigured || len(item.PresentEnvKeys) > 0
-		item.Enabled = configEnabled || (len(item.PresentEnvKeys) > 0 && len(item.MissingEnvKeys) == 0)
+		switch {
+		case explicitEnabledSet:
+			item.Enabled = explicitEnabledValue
+		case configConfigured:
+			item.Enabled = configEnabled
+		default:
+			item.Enabled = len(item.PresentEnvKeys) > 0 && len(item.MissingEnvKeys) == 0
+		}
 		item.RuntimeStatus, item.LastEvidence, item.LastError = analyzeHermesPlatformEvidence(spec.ID, status)
 		if !item.Configured && (item.LastEvidence != "" || item.LastError != "") {
 			item.Configured = true
-		}
-		if !item.Enabled && status.GatewayRunning && (item.RuntimeStatus == "healthy" || item.RuntimeStatus == "warning" || item.RuntimeStatus == "error") {
-			item.Enabled = true
 		}
 		item.Detail = strings.TrimSpace(strings.Join([]string{
 			ternary(configConfigured, "检测到 config.yaml 配置。", ""),
@@ -1308,6 +1427,7 @@ func buildHermesPlatformDetail(configState HermesConfigState, id string) (*Herme
 		Status:      status,
 		Config:      configBlock,
 		Environment: envValues,
+		Fields:      buildHermesPlatformFields(spec),
 	}, true
 }
 
@@ -2403,30 +2523,19 @@ func GetHermesActions() gin.HandlerFunc {
 
 func GetHermesOverview(cfg *config.Config, tm *taskman.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		_ = tm
 		status := detectHermesStatus(cfg)
 		configState := buildHermesConfigState(cfg)
-		data := detectHermesDataSummary(status)
-		storage := scanHermesStorage(status)
 		platforms := detectHermesPlatforms(configState)
-		logFiles := listHermesLogFiles(status)
-		tasks, taskSummary := collectHermesTasks(tm)
-		health := buildHermesHealthSnapshot(status, data, logFiles, taskSummary)
 		doctor := readHermesDoctorSnapshot(cfg)
 		c.JSON(http.StatusOK, gin.H{
 			"ok": true,
-			"overview": HermesOverview{
-				Status:      status,
-				Config:      configState,
-				Actions:     hermesActionCatalog(),
-				Data:        data,
-				Health:      health,
-				Storage:     storage,
-				Platforms:   platforms,
-				Doctor:      doctor,
-				LogFiles:    logFiles,
-				RecentTasks: tasks,
-				TaskSummary: taskSummary,
-				Warnings:    detectHermesWarnings(status, data),
+			"overview": gin.H{
+				"status":    status,
+				"actions":   hermesActionCatalog(),
+				"platforms": platforms,
+				"doctor":    doctor,
+				"warnings":  detectHermesOverviewWarnings(status),
 			},
 		})
 	}
@@ -2541,7 +2650,22 @@ func GetHermesHealth(cfgs ...*config.Config) gin.HandlerFunc {
 func GetHermesPlatforms(cfgs ...*config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		configState := buildHermesConfigState(cfgs...)
-		c.JSON(http.StatusOK, gin.H{"ok": true, "platforms": detectHermesPlatforms(configState)})
+		snapshot := detectHermesPlatforms(configState)
+		detailsByID := map[string]*HermesPlatformDetail{}
+		for _, platform := range snapshot.Platforms {
+			if detail, ok := buildHermesPlatformDetail(configState, platform.ID); ok {
+				detailsByID[platform.ID] = detail
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"ok": true,
+			"platforms": gin.H{
+				"platforms":       snapshot.Platforms,
+				"configuredCount": snapshot.ConfiguredCount,
+				"enabledCount":    snapshot.EnabledCount,
+				"detailsById":     detailsByID,
+			},
+		})
 	}
 }
 

--- a/internal/handler/panel_chat.go
+++ b/internal/handler/panel_chat.go
@@ -441,9 +441,7 @@ func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigP
 	}
 	agentsMap["list"] = newList
 	obj["agents"] = agentsMap
-
-	// Ensure panel chat uses the official session store to sync with OpenClaw
-	obj["sessionDir"] = filepath.ToSlash(filepath.Join(cfg.OpenClawDir, "sessions"))
+	sanitizePanelChatRuntimeConfig(obj)
 	delete(obj, "channels")
 	delete(obj, "plugins")
 	encoded, err := json.MarshalIndent(obj, "", "  ")
@@ -451,6 +449,16 @@ func rewritePanelChatRuntimeConfig(cfg *config.Config, srcConfigPath, dstConfigP
 		return err
 	}
 	return os.WriteFile(dstConfigPath, append(encoded, '\n'), 0o644)
+}
+
+func sanitizePanelChatRuntimeConfig(obj map[string]interface{}) {
+	if obj == nil {
+		return
+	}
+	// Newer OpenClaw versions no longer accept these legacy root-level keys in
+	// ephemeral runtime configs generated for panel chat.
+	delete(obj, "sessionDir")
+	delete(obj, "model")
 }
 
 func buildPanelChatTitle(input string) string {
@@ -618,6 +626,15 @@ func loadPanelChatParticipants(db *sql.DB, cfg *config.Config, session panelChat
 	if len(views) == 0 && strings.TrimSpace(session.AgentID) != "" {
 		views = append(views, panelChatParticipantView{AgentID: session.AgentID, Name: nameMap[session.AgentID], RoleType: "assistant", OrderIndex: 0, AutoReply: true, Enabled: true})
 	}
+	sort.SliceStable(views, func(i, j int) bool {
+		if views[i].IsSummary != views[j].IsSummary {
+			return !views[i].IsSummary
+		}
+		if views[i].OrderIndex != views[j].OrderIndex {
+			return views[i].OrderIndex < views[j].OrderIndex
+		}
+		return views[i].AgentID < views[j].AgentID
+	})
 	return views, nil
 }
 
@@ -1043,6 +1060,13 @@ func executeGroupPanelChat(ctx context.Context, db *sql.DB, cfg *config.Config, 
 		"timestamp":   userTimestamp,
 	}
 	messages = append(messages, userEntry)
+	_ = savePanelChatMessages(cfg, session.ID, messages)
+	_, _ = updatePanelChatSessionState(cfg, session.ID, func(item *panelChatSession) {
+		item.Processing = true
+		item.UpdatedAt = time.Now().UnixMilli()
+		item.MessageCount = len(messages)
+		item.LastMessage = strings.TrimSpace(userMessage)
+	})
 	lastReply := ""
 	for _, participant := range participants {
 		if !participant.Enabled || !participant.AutoReply {
@@ -1110,6 +1134,15 @@ func executeGroupPanelChat(ctx context.Context, db *sql.DB, cfg *config.Config, 
 			entry["sources"] = sources
 		}
 		messages = append(messages, entry)
+		_ = savePanelChatMessages(cfg, session.ID, messages)
+		_, _ = updatePanelChatSessionState(cfg, session.ID, func(item *panelChatSession) {
+			item.Processing = true
+			item.CurrentAgentID = participant.AgentID
+			item.CurrentAgentName = agentName
+			item.UpdatedAt = time.Now().UnixMilli()
+			item.MessageCount = len(messages)
+			item.LastMessage = strings.TrimSpace(userMessage)
+		})
 	}
 	return messages, lastReply, sessionIDs, nil
 }

--- a/internal/taskman/taskman.go
+++ b/internal/taskman/taskman.go
@@ -271,6 +271,8 @@ func (m *Manager) runCommandWithInput(task *Task, input io.Reader, name string, 
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+	task.SetProgress(10)
+	m.broadcastTaskUpdate(task)
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 1024*64), 1024*64)

--- a/scripts/install-lite-macos.sh
+++ b/scripts/install-lite-macos.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 CLAWPANEL_PUBLIC_BASE="${CLAWPANEL_PUBLIC_BASE:-http://43.248.142.249:19527}"
 CLAWPANEL_PUBLIC_BASE="${CLAWPANEL_PUBLIC_BASE%/}"
 INSTALL_DIR="/opt/clawpanel-lite"
+DATA_DIR="/var/lib/clawpanel-lite"
 SERVICE_LABEL="com.clawpanel.lite.service"
 REPO="zhaoxinyi02/ClawPanel"
 TAG_PREFIX="lite-v"
@@ -133,6 +134,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 TOTAL_STEPS=4
 
 info "安装目录: ${INSTALL_DIR}"
+info "数据目录: ${DATA_DIR}"
 info "服务标签: ${SERVICE_LABEL}"
 info "目标架构: darwin/${ARCH}"
 echo ""
@@ -159,6 +161,18 @@ log "下载完成：$PACKAGE_NAME"
 
 step 2 $TOTAL_STEPS "部署 Lite 运行环境"
 mkdir -p "$INSTALL_DIR"
+mkdir -p "$DATA_DIR"
+
+LEGACY_DATA_DIR="$INSTALL_DIR/data"
+if [[ -d "$LEGACY_DATA_DIR" ]]; then
+  if [[ ! -e "$DATA_DIR/clawpanel.json" ]] && [[ ! -e "$DATA_DIR/openclaw-config/openclaw.json" ]]; then
+    info "检测到旧版内置数据目录，迁移到外部持久化目录..."
+    cp -a "$LEGACY_DATA_DIR/." "$DATA_DIR/"
+  else
+    info "检测到旧版内置数据目录，但外部数据目录已有内容，跳过自动覆盖。"
+  fi
+fi
+
 rm -rf "$INSTALL_DIR"/*
 tar -xzf "$TMP_DIR/$PACKAGE_NAME" -C "$INSTALL_DIR"
 chmod +x "$INSTALL_DIR/clawpanel-lite" "$INSTALL_DIR/bin/clawlite-openclaw"
@@ -168,6 +182,8 @@ fi
 if [[ -f "$INSTALL_DIR/runtime/node/node" ]]; then
   chmod +x "$INSTALL_DIR/runtime/node/node"
 fi
+rm -rf "$INSTALL_DIR/data"
+ln -sfn "$DATA_DIR" "$INSTALL_DIR/data"
 ln -sf "$INSTALL_DIR/clawpanel-lite" /usr/local/bin/clawpanel-lite
 ln -sf "$INSTALL_DIR/bin/clawlite-openclaw" /usr/local/bin/clawlite-openclaw
 log "Lite 文件已部署到 ${INSTALL_DIR}"
@@ -189,7 +205,7 @@ cat > "/Library/LaunchDaemons/${SERVICE_LABEL}.plist" <<EOF
   <key>EnvironmentVariables</key>
   <dict>
     <key>CLAWPANEL_EDITION</key><string>lite</string>
-    <key>CLAWPANEL_DATA</key><string>${INSTALL_DIR}/data</string>
+    <key>CLAWPANEL_DATA</key><string>${DATA_DIR}</string>
     <key>NODE_OPTIONS</key><string>--max-old-space-size=2048</string>
   </dict>
 </dict>
@@ -209,6 +225,7 @@ log "ClawPanel Lite macOS 安装完成"
 echo ""
 printf "${GREEN}•${NC} 当前版本: ${BOLD}%s${NC}\n" "$VERSION"
 printf "${GREEN}•${NC} 安装目录: ${BOLD}%s${NC}\n" "$INSTALL_DIR"
+printf "${GREEN}•${NC} 数据目录: ${BOLD}%s${NC}\n" "$DATA_DIR"
 printf "${GREEN}•${NC} 服务标签: ${BOLD}%s${NC}\n" "$SERVICE_LABEL"
 printf "${GREEN}•${NC} Lite CLI: ${BOLD}clawlite-openclaw${NC}\n"
 printf "${GREEN}•${NC} 面板地址: ${BOLD}http://%s:19527${NC}\n" "$HOST_IP"

--- a/scripts/install-lite.ps1
+++ b/scripts/install-lite.ps1
@@ -7,6 +7,7 @@ $TagPrefix = "lite-v"
 $AccelBase = if ($env:ACCEL_BASE) { $env:ACCEL_BASE } else { "$ClawPanelPublicBase/api/panel/update-mirror" }
 $AccelMeta = if ($env:ACCEL_META_URL) { $env:ACCEL_META_URL } else { "$AccelBase/lite" }
 $InstallDir = "C:\ClawPanelLite"
+$DataDir = "C:\ProgramData\ClawPanelLite"
 $ServiceName = "clawpanel-lite"
 
 function Get-LatestVersionFromGitHub {
@@ -59,9 +60,25 @@ if (-not $LocalPackage) {
 }
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+New-Item -ItemType Directory -Force -Path $DataDir | Out-Null
 Get-Service $ServiceName -ErrorAction SilentlyContinue | Stop-Service -Force -ErrorAction SilentlyContinue
+
+$legacyDataDir = Join-Path $InstallDir "data"
+if (Test-Path $legacyDataDir) {
+  $hasExternalData = (Test-Path (Join-Path $DataDir "clawpanel.json")) -or (Test-Path (Join-Path $DataDir "openclaw-config\openclaw.json"))
+  if (-not $hasExternalData) {
+    Write-Host "  [Lite] 检测到旧版内置数据目录，迁移到外部持久化目录..." -ForegroundColor Cyan
+    Copy-Item -Path (Join-Path $legacyDataDir '*') -Destination $DataDir -Recurse -Force -ErrorAction SilentlyContinue
+  } else {
+    Write-Host "  [Lite] 检测到旧版内置数据目录，但外部数据目录已有内容，跳过自动覆盖。" -ForegroundColor Cyan
+  }
+}
+
 Remove-Item "$InstallDir\*" -Recurse -Force -ErrorAction SilentlyContinue
 tar -xzf $tmp -C $InstallDir
+
+Remove-Item "$InstallDir\data" -Recurse -Force -ErrorAction SilentlyContinue
+cmd /c mklink /D "$InstallDir\data" "$DataDir" | Out-Null
 
 Rename-Item -Path "$InstallDir\clawpanel-lite.exe" -NewName "clawpanel-lite.exe" -ErrorAction SilentlyContinue
 New-Item -ItemType SymbolicLink -Path "C:\Windows\System32\clawlite-openclaw.cmd" -Target "$InstallDir\bin\clawlite-openclaw.cmd" -Force | Out-Null
@@ -69,7 +86,8 @@ New-Item -ItemType SymbolicLink -Path "C:\Windows\System32\clawlite-openclaw.cmd
 sc.exe delete $ServiceName 2>$null | Out-Null
 Start-Sleep -Seconds 1
 sc.exe create $ServiceName binPath= "`"$InstallDir\clawpanel-lite.exe`"" start= auto DisplayName= "ClawPanel Lite v$Version" | Out-Null
-reg add "HKLM\SYSTEM\CurrentControlSet\Services\$ServiceName" /v Environment /t REG_MULTI_SZ /d "CLAWPANEL_EDITION=lite\0CLAWPANEL_DATA=$InstallDir\data\0NODE_OPTIONS=--max-old-space-size=2048\0" /f | Out-Null
+reg add "HKLM\SYSTEM\CurrentControlSet\Services\$ServiceName" /v Environment /t REG_MULTI_SZ /d "CLAWPANEL_EDITION=lite\0CLAWPANEL_DATA=$DataDir\0NODE_OPTIONS=--max-old-space-size=2048\0" /f | Out-Null
 sc.exe start $ServiceName | Out-Null
 
 Write-Host "ClawPanel Lite for Windows installed at: $InstallDir"
+Write-Host "ClawPanel Lite data stored at: $DataDir"

--- a/scripts/install-lite.sh
+++ b/scripts/install-lite.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 CLAWPANEL_PUBLIC_BASE="${CLAWPANEL_PUBLIC_BASE:-http://43.248.142.249:19527}"
 CLAWPANEL_PUBLIC_BASE="${CLAWPANEL_PUBLIC_BASE%/}"
 INSTALL_DIR="/opt/clawpanel-lite"
+DATA_DIR="/var/lib/clawpanel-lite"
 SERVICE_NAME="clawpanel-lite"
 BIN_NAME="clawpanel-lite"
 PORT="19527"
@@ -200,7 +201,9 @@ echo ""
 
 step 1 $TOTAL_STEPS "准备安装目录"
 mkdir -p "$INSTALL_DIR"
+mkdir -p "$DATA_DIR"
 log "目录已就绪: $INSTALL_DIR"
+log "数据目录已就绪: $DATA_DIR"
 
 step 2 $TOTAL_STEPS "下载 ClawPanel Lite v${VERSION}"
 if [[ -n "$LOCAL_PACKAGE_PATH" ]]; then
@@ -218,10 +221,24 @@ log "下载完成 (${DOWNLOAD_SOURCE_ACTUAL})"
 
 step 3 $TOTAL_STEPS "部署 Lite 运行环境"
 systemctl stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+LEGACY_DATA_DIR="$INSTALL_DIR/data"
 DATA_OWNER=""
-if [[ -d "$INSTALL_DIR/data" ]] && command -v stat >/dev/null 2>&1; then
-  DATA_OWNER=$(stat -c '%u:%g' "$INSTALL_DIR/data" 2>/dev/null || true)
+if [[ -d "$DATA_DIR" ]] && command -v stat >/dev/null 2>&1; then
+	DATA_OWNER=$(stat -c '%u:%g' "$DATA_DIR" 2>/dev/null || true)
+elif [[ -d "$LEGACY_DATA_DIR" ]] && command -v stat >/dev/null 2>&1; then
+	DATA_OWNER=$(stat -c '%u:%g' "$LEGACY_DATA_DIR" 2>/dev/null || true)
 fi
+
+if [[ -d "$LEGACY_DATA_DIR" ]]; then
+	if [[ ! -e "$DATA_DIR/clawpanel.json" ]] && [[ ! -e "$DATA_DIR/openclaw-config/openclaw.json" ]]; then
+		info "检测到旧版内置数据目录，迁移到外部持久化目录..."
+		mkdir -p "$DATA_DIR"
+		cp -a "$LEGACY_DATA_DIR/." "$DATA_DIR/"
+	else
+		info "检测到旧版内置数据目录，但外部数据目录已有内容，跳过自动覆盖。"
+	fi
+fi
+
 rm -rf "$INSTALL_DIR"/*
 tar -xzf "$TMP_DIR/$PACKAGE_NAME" -C "$INSTALL_DIR"
 chmod +x "$INSTALL_DIR/$BIN_NAME" "$INSTALL_DIR/bin/clawlite-openclaw"
@@ -231,9 +248,12 @@ fi
 if [[ -f "$INSTALL_DIR/runtime/node/node" ]]; then
   chmod +x "$INSTALL_DIR/runtime/node/node"
 fi
-if [[ -n "$DATA_OWNER" ]] && [[ -d "$INSTALL_DIR/data" ]]; then
-  chown -R "$DATA_OWNER" "$INSTALL_DIR/data" 2>/dev/null || true
+mkdir -p "$DATA_DIR"
+if [[ -n "$DATA_OWNER" ]] && [[ -d "$DATA_DIR" ]]; then
+	chown -R "$DATA_OWNER" "$DATA_DIR" 2>/dev/null || true
 fi
+rm -rf "$INSTALL_DIR/data"
+ln -sfn "$DATA_DIR" "$INSTALL_DIR/data"
 ln -sf "$INSTALL_DIR/$BIN_NAME" /usr/local/bin/clawpanel-lite
 ln -sf "$INSTALL_DIR/bin/clawlite-openclaw" /usr/local/bin/clawlite-openclaw
 log "Lite 文件已部署"
@@ -252,7 +272,7 @@ ExecStart=${INSTALL_DIR}/${BIN_NAME}
 Restart=always
 RestartSec=5
 Environment=CLAWPANEL_EDITION=lite
-Environment=CLAWPANEL_DATA=${INSTALL_DIR}/data
+Environment=CLAWPANEL_DATA=${DATA_DIR}
 Environment=NODE_OPTIONS=--max-old-space-size=2048
 
 [Install]
@@ -269,6 +289,7 @@ log "ClawPanel Lite 安装完成"
 echo ""
 echo -e "${GREEN}•${NC} 当前版本: ${BOLD}${VERSION}${NC}"
 echo -e "${GREEN}•${NC} 安装目录: ${BOLD}${INSTALL_DIR}${NC}"
+echo -e "${GREEN}•${NC} 数据目录: ${BOLD}${DATA_DIR}${NC}"
 echo -e "${GREEN}•${NC} 服务名称: ${BOLD}${SERVICE_NAME}${NC}"
 echo -e "${GREEN}•${NC} Lite CLI: ${BOLD}clawlite-openclaw${NC}"
 echo -e "${GREEN}•${NC} 访问地址: ${BOLD}http://${SERVICE_IP}:${PORT}${NC}"

--- a/web/src/components/ConfigFieldRenderer.tsx
+++ b/web/src/components/ConfigFieldRenderer.tsx
@@ -1,0 +1,136 @@
+import { Check } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+export type SharedConfigField = {
+  key: string;
+  label: string;
+  type: 'text' | 'password' | 'toggle' | 'number' | 'select' | 'textarea';
+  options?: string[];
+  placeholder?: string;
+  help?: string;
+  rows?: number;
+};
+
+type Props = {
+  field: SharedConfigField;
+  value: any;
+  textareaValue?: string;
+  hasExplicitValue: boolean;
+  onChange: (value: string) => void;
+  onToggle?: () => void;
+  fullWidth?: boolean;
+  fieldHelp?: string;
+  emptyOptionLabel?: string;
+  compactToggle?: boolean;
+  toggleStateLabel?: string;
+  accent?: 'violet' | 'blue';
+  renderFooter?: ReactNode;
+};
+
+export default function ConfigFieldRenderer({
+  field,
+  value,
+  textareaValue = '',
+  hasExplicitValue,
+  onChange,
+  onToggle,
+  fullWidth,
+  fieldHelp,
+  emptyOptionLabel,
+  compactToggle,
+  toggleStateLabel,
+  accent = 'violet',
+  renderFooter,
+}: Props) {
+  const accentClass = accent === 'blue'
+    ? {
+        ring: 'focus:ring-blue-100 dark:focus:ring-blue-900/30 focus:border-blue-500',
+        toggle: value ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600',
+        toggleFocus: 'focus:ring-blue-500',
+        text: value ? 'text-blue-600 dark:text-blue-400 font-medium' : 'text-gray-500',
+      }
+    : {
+        ring: 'focus:ring-violet-100 dark:focus:ring-violet-900/30 focus:border-violet-500',
+        toggle: value ? 'bg-violet-600' : 'bg-gray-300 dark:bg-gray-600',
+        toggleFocus: 'focus:ring-violet-500',
+        text: value ? 'text-violet-600 dark:text-violet-400 font-medium' : 'text-gray-500',
+      };
+
+  return (
+    <div key={field.key} className={fullWidth || field.type === 'textarea' ? 'md:col-span-2' : ''}>
+      {field.type !== 'toggle' && (
+        <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1.5">
+          {field.label}
+        </label>
+      )}
+
+      {field.type === 'toggle' ? (
+        <div
+          className={`rounded-lg border transition-colors ${compactToggle
+            ? 'flex items-start justify-between gap-4 px-4 py-3 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 h-full'
+            : 'flex items-center gap-3 p-3 border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-900/30'}`}
+        >
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold text-gray-900 dark:text-white">{field.label}</div>
+            {fieldHelp && <p className="mt-1 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">{fieldHelp}</p>}
+          </div>
+          <button
+            type="button"
+            onClick={onToggle}
+            className={`relative shrink-0 w-9 h-5 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 ${accentClass.toggleFocus} ${accentClass.toggle}`}
+          >
+            <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${value ? 'translate-x-4' : ''}`} />
+          </button>
+          {toggleStateLabel && <span className={`text-xs ${accentClass.text}`}>{toggleStateLabel}</span>}
+        </div>
+      ) : field.type === 'select' ? (
+        <div className="relative">
+          <select
+            name={field.key}
+            value={value ?? ''}
+            onChange={e => onChange(e.target.value)}
+            className={`w-full px-3.5 py-2 text-sm border rounded-lg bg-white dark:bg-gray-900 transition-all focus:ring-2 outline-none ${accentClass.ring}
+              ${hasExplicitValue ? 'border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'border-gray-200 dark:border-gray-800 text-gray-400'}`}
+          >
+            <option value="">{emptyOptionLabel || field.placeholder || 'Not configured'}</option>
+            {field.options?.map(opt => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        </div>
+      ) : field.type === 'textarea' ? (
+        <textarea
+          name={field.key}
+          rows={field.rows || 3}
+          value={textareaValue}
+          onChange={e => onChange(e.target.value)}
+          placeholder={field.placeholder || 'Not configured'}
+          className={`w-full px-3.5 py-2 text-sm border rounded-lg bg-white dark:bg-gray-900 transition-all focus:ring-2 outline-none resize-y ${accentClass.ring}
+            ${hasExplicitValue ? 'border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'border-gray-200 dark:border-gray-800 text-gray-400'}`}
+        />
+      ) : (
+        <div className="relative">
+          <input
+            name={field.key}
+            type={field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'}
+            value={value ?? ''}
+            onChange={e => onChange(e.target.value)}
+            placeholder={field.placeholder || 'Not configured'}
+            className={`w-full px-3.5 py-2 text-sm border rounded-lg bg-white dark:bg-gray-900 transition-all focus:ring-2 outline-none pr-8 ${accentClass.ring}
+              ${hasExplicitValue ? 'border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'border-gray-200 dark:border-gray-800 text-gray-400'}`}
+          />
+          {hasExplicitValue && (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2 text-emerald-500">
+              <Check size={14} strokeWidth={3} />
+            </div>
+          )}
+        </div>
+      )}
+
+      {field.type !== 'toggle' && fieldHelp && (
+        <p className="mt-1.5 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">{fieldHelp}</p>
+      )}
+      {renderFooter}
+    </div>
+  );
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { Outlet, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
   LayoutDashboard, ScrollText, Radio, Sparkles, Clock, Settings,
   Moon, Sun, LogOut, Menu, FolderOpen, Languages, MessageSquare,
-  RotateCw, RefreshCw, Power, Puzzle, Bot, Search, Bell, ChevronDown, GitBranch, Network, BriefcaseBusiness, Activity, Brain, TerminalSquare, FileStack,
+  RotateCw, RefreshCw, Power, Puzzle, Bot, Search, Bell, ChevronDown, GitBranch, Network, BriefcaseBusiness, Activity, Brain, TerminalSquare, FileStack, Key, X,
 } from 'lucide-react';
 import { useI18n } from '../i18n';
 import AIAssistant from './AIAssistant';
@@ -65,6 +65,120 @@ function filterVisibleTasks(tasks: TaskInfo[]) {
   return tasks.filter(task => !(task.type === 'workflow_run' && task.status === 'canceled'));
 }
 
+function PanelSettingsModal({ open, onClose, onLogout, locale }: { open: boolean; onClose: () => void; onLogout: () => void; locale: string }) {
+  const [oldPwd, setOldPwd] = useState('');
+  const [newPwd, setNewPwd] = useState('');
+  const [confirmPwd, setConfirmPwd] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState('');
+  const [msgOk, setMsgOk] = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleChangePassword = async () => {
+    if (!oldPwd || !newPwd || !confirmPwd) return;
+    if (newPwd !== confirmPwd) {
+      setMsg(locale === 'zh-CN' ? '两次输入的密码不一致' : 'Passwords do not match');
+      setMsgOk(false);
+      return;
+    }
+    if (newPwd.length < 4) {
+      setMsg(locale === 'zh-CN' ? '密码至少4位' : 'Password must be at least 4 characters');
+      setMsgOk(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      const r = await api.changePassword(oldPwd, newPwd);
+      if (r?.ok) {
+        setMsg(locale === 'zh-CN' ? '密码修改成功，即将退出登录...' : 'Password changed, logging out...');
+        setMsgOk(true);
+        setTimeout(() => {
+          onClose();
+          onLogout();
+        }, 1600);
+      } else {
+        setMsg(r?.error === 'Wrong current password'
+          ? (locale === 'zh-CN' ? '当前密码错误' : 'Current password is incorrect')
+          : (r?.error || (locale === 'zh-CN' ? '修改失败' : 'Change failed')));
+        setMsgOk(false);
+      }
+    } catch {
+      setMsg(locale === 'zh-CN' ? '修改失败' : 'Change failed');
+      setMsgOk(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[220] flex items-center justify-center bg-slate-950/55 px-4 backdrop-blur-sm" onClick={onClose}>
+      <div className="w-full max-w-2xl rounded-[28px] border border-blue-100/80 bg-[linear-gradient(145deg,rgba(255,255,255,0.98),rgba(239,246,255,0.92))] p-6 shadow-[0_28px_80px_rgba(15,23,42,0.22)] dark:border-blue-800/30 dark:bg-[linear-gradient(145deg,rgba(12,24,42,0.98),rgba(30,64,175,0.16))]" onClick={e => e.stopPropagation()}>
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="inline-flex items-center gap-2 rounded-full border border-blue-200/70 bg-blue-50/70 px-3 py-1 text-[11px] font-semibold text-blue-600 dark:border-blue-800/40 dark:bg-blue-950/30 dark:text-blue-300">
+              <Settings size={13} />
+              {locale === 'zh-CN' ? '面板设置' : 'Panel Settings'}
+            </div>
+            <h3 className="mt-3 text-lg font-semibold text-slate-900 dark:text-white">
+              {locale === 'zh-CN' ? '管理面板登录与本地设置' : 'Panel login and local settings'}
+            </h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {locale === 'zh-CN' ? '这里只放与 ClawPanel 面板自身相关的配置，不影响 OpenClaw 或 Hermes 平台参数。' : 'This dialog only contains ClawPanel-specific settings, separate from OpenClaw and Hermes.'}
+            </p>
+          </div>
+          <button onClick={onClose} className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white/70 text-slate-500 transition-colors hover:text-slate-800 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-400 dark:hover:text-white">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="mt-6">
+          <div className="rounded-[24px] border border-gray-100 bg-white/90 p-5 dark:border-gray-800 dark:bg-slate-900/55">
+            <div className="flex items-center gap-3">
+              <div className="rounded-xl border border-blue-100/70 bg-blue-100/80 p-1.5 text-blue-600 dark:border-blue-800/30 dark:bg-blue-900/20">
+                <Key size={16} />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-slate-900 dark:text-white">{locale === 'zh-CN' ? '修改管理密码' : 'Change Admin Password'}</h3>
+                <p className="text-[10px] text-slate-500 dark:text-slate-400">{locale === 'zh-CN' ? '修改后需重新登录面板。' : 'You will need to log in again after changing it.'}</p>
+              </div>
+            </div>
+            <div className="mt-4 space-y-3">
+              <div className="grid grid-cols-1 gap-3">
+                <input type="password" value={oldPwd} onChange={e => setOldPwd(e.target.value)} placeholder={locale === 'zh-CN' ? '当前密码' : 'Current password'} className="w-full rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-xs transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900" />
+                <input type="password" value={newPwd} onChange={e => setNewPwd(e.target.value)} placeholder={locale === 'zh-CN' ? '新密码' : 'New password'} className="w-full rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-xs transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900" />
+                <input type="password" value={confirmPwd} onChange={e => setConfirmPwd(e.target.value)} placeholder={locale === 'zh-CN' ? '确认新密码' : 'Confirm password'} className="w-full rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-xs transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900" />
+              </div>
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <p className="text-[11px] leading-relaxed text-slate-500 dark:text-slate-400">
+                  {locale === 'zh-CN' ? '修改成功后会自动退出当前登录态，请使用新密码重新进入面板。' : 'After a successful change, the current session will be logged out automatically.'}
+                </p>
+                <button onClick={handleChangePassword} disabled={saving || !oldPwd || !newPwd || !confirmPwd} className="page-modern-accent px-4 py-2.5 text-xs font-medium disabled:opacity-50">
+                  {saving ? (locale === 'zh-CN' ? '修改中...' : 'Saving...') : (locale === 'zh-CN' ? '修改密码' : 'Change Password')}
+                </button>
+              </div>
+              {msg && (
+                <div className={`rounded-lg border px-3 py-2 text-xs ${msgOk ? 'border-emerald-100 bg-emerald-50 text-emerald-600 dark:border-emerald-900/30 dark:bg-emerald-900/20 dark:text-emerald-300' : 'border-red-100 bg-red-50 text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-300'}`}>
+                  {msg}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function LayoutShell({ onLogout, napcatStatus, wechatStatus, openclawStatus, processStatus, wsMessages }: Props) {
   const { t, locale, setLocale } = useI18n();
   const navigate = useNavigate();
@@ -91,6 +205,7 @@ function LayoutShell({ onLogout, napcatStatus, wechatStatus, openclawStatus, pro
   const [searchQuery, setSearchQuery] = useState('');
   const [searchOpen, setSearchOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
+  const [panelSettingsOpen, setPanelSettingsOpen] = useState(false);
   const [hermesOverview, setHermesOverview] = useState<any | null>(null);
   const searchRef = useRef<HTMLDivElement | null>(null);
   const profileRef = useRef<HTMLDivElement | null>(null);
@@ -331,23 +446,21 @@ function LayoutShell({ onLogout, napcatStatus, wechatStatus, openclawStatus, pro
   // Build channel list from enabledChannels returned by /api/status
   const connectedChannels = useMemo(() => {
     if (isHermesBoard) {
-      const hermesPlatforms = Array.isArray(hermesOverview?.platforms?.platforms) ? hermesOverview.platforms.platforms : [];
-      const hermesChannels: RuntimeChannelSummary[] = hermesPlatforms
-        .filter((platform: any) => platform?.configured || platform?.enabled || platform?.runtimeStatus === 'healthy' || platform?.runtimeStatus === 'warning' || platform?.runtimeStatus === 'error')
-        .map((platform: any) => {
-          const connected = platform?.runtimeStatus === 'healthy' || platform?.runtimeStatus === 'warning';
-          const detail = platform?.lastError
-            ? platform.lastError
-            : platform?.lastEvidence
-              ? platform.lastEvidence
-              : platform?.enabled
-                ? t.common.enabled
-                : locale === 'zh-CN'
-                  ? '未启用'
-                  : 'Not enabled';
-          return {
-            label: platform?.label || platform?.id || 'Platform',
-            detail,
+		const hermesPlatforms = Array.isArray(hermesOverview?.platforms?.platforms) ? hermesOverview.platforms.platforms : [];
+		const hermesChannels: RuntimeChannelSummary[] = hermesPlatforms
+			.filter((platform: any) => platform?.enabled)
+			.map((platform: any) => {
+				const connected = platform?.runtimeStatus === 'healthy' || platform?.runtimeStatus === 'warning';
+				const detail = platform?.runtimeStatus === 'error'
+					? (locale === 'zh-CN' ? '运行异常' : 'Runtime Error')
+					: connected
+						? (locale === 'zh-CN' ? '运行中' : 'Running')
+						: platform?.enabled
+							? (locale === 'zh-CN' ? '已启用' : 'Enabled')
+							: (locale === 'zh-CN' ? '未启用' : 'Not enabled');
+				return {
+					label: platform?.label || platform?.id || 'Platform',
+					detail,
             connected,
           };
         });
@@ -400,7 +513,7 @@ function LayoutShell({ onLogout, napcatStatus, wechatStatus, openclawStatus, pro
     return channels.slice(0, 5);
   }, [hermesOverview, isHermesBoard, locale, napcatStatus, openclawStatus, t, wechatStatus]);
   const totalEnabledChannels = isHermesBoard
-    ? (hermesOverview?.platforms?.platforms || []).filter((platform: any) => platform?.configured || platform?.enabled || platform?.runtimeStatus === 'healthy' || platform?.runtimeStatus === 'warning' || platform?.runtimeStatus === 'error').length
+    ? (hermesOverview?.platforms?.platforms || []).filter((platform: any) => platform?.enabled).length
     : (openclawStatus?.enabledChannels || []).length;
   const runtime = useMemo(() => resolveOpenClawRuntime(openclawStatus, processStatus), [openclawStatus, processStatus]);
   const openClawRestartHint = processStatus?.managedExternally
@@ -630,8 +743,11 @@ function LayoutShell({ onLogout, napcatStatus, wechatStatus, openclawStatus, pro
                     </button>
                     <div className="mx-2 mb-2 border-t border-slate-200/80 dark:border-slate-700/80" />
                     <div className="px-3 pb-2 text-[11px] text-slate-400">
-                      Admin
+                      {locale === 'zh-CN' ? '面板设置' : 'Panel Settings'}
                     </div>
+                    <button onClick={() => { setProfileOpen(false); setPanelSettingsOpen(true); }} className="mb-1 w-full flex items-center gap-2 px-3 py-2 rounded-xl text-sm text-slate-700 hover:bg-slate-50 transition-colors dark:text-slate-200 dark:hover:bg-slate-800">
+                      <Settings size={15} /> {locale === 'zh-CN' ? '面板设置' : 'Panel Settings'}
+                    </button>
                     <button onClick={() => { setProfileOpen(false); onLogout(); }} className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-sm text-red-600 hover:bg-red-50 transition-colors">
                       <LogOut size={15} /> 退出登录
                     </button>
@@ -711,6 +827,7 @@ function LayoutShell({ onLogout, napcatStatus, wechatStatus, openclawStatus, pro
         </div>
       </nav>
       <AIAssistant />
+      <PanelSettingsModal open={panelSettingsOpen} onClose={() => setPanelSettingsOpen(false)} onLogout={onLogout} locale={locale} />
     </div>
   );
 }

--- a/web/src/pages/Channels.tsx
+++ b/web/src/pages/Channels.tsx
@@ -4,6 +4,7 @@ import QRCode from 'qrcode';
 import { api } from '../lib/api';
 import { Radio, Wifi, WifiOff, QrCode, Key, Zap, UserCheck, Check, X, Power, Loader2, RefreshCw, LogOut, Sparkles, Download, Package, Wrench, Search, Copy, CheckCircle, AlertTriangle, AlertCircle, Trash2, ChevronDown } from 'lucide-react';
 import InfoTooltip from '../components/InfoTooltip';
+import ConfigFieldRenderer from '../components/ConfigFieldRenderer';
 import { useI18n } from '../i18n';
 
 type ChannelFieldSection = 'default' | 'access' | 'conversation' | 'advanced';
@@ -2089,116 +2090,46 @@ export default function Channels() {
       : '';
 
     return (
-      <div key={field.key} className={isFullWidth ? 'md:col-span-2' : ''}>
-        {field.type !== 'toggle' && (
-          <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1.5">
-            {field.label}
-          </label>
-        )}
-
-        {field.type === 'toggle' ? (
-          <div
-            className={`rounded-lg border transition-colors ${
-              isCompactToggle
-                ? 'flex items-start justify-between gap-4 px-4 py-3 border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 h-full'
-                : 'flex items-center gap-3 p-3 border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-900/30'
-            }`}
-          >
-            {isCompactToggle && (
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-semibold text-gray-900 dark:text-white">{field.label}</div>
-                {field.help && (
-                  <p className="mt-1 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">{field.help}</p>
+      <ConfigFieldRenderer
+        key={field.key}
+        field={{ ...field, options: fieldOptions }}
+        value={currentVal}
+        textareaValue={textareaValue}
+        hasExplicitValue={hasExplicitValue}
+        onChange={value => handleFieldDraftChange(channelId, field, value)}
+        onToggle={() => handleToggleField(channelId, field.key)}
+        fullWidth={isFullWidth}
+        fieldHelp={fieldHelp}
+        emptyOptionLabel={defaultHint ? t.channels.notConfiguredWithDefault.replace('{value}', defaultHint) : t.common.notConfigured}
+        compactToggle={isCompactToggle}
+        toggleStateLabel={currentVal ? t.channels.opened : t.channels.closed}
+        accent="violet"
+        renderFooter={(
+          <>
+            {defaultHint && (
+              <p className="mt-1 text-[11px] text-gray-400">
+                {t.channels.defaultWhenUnset.replace('{value}', defaultHint)}
+              </p>
+            )}
+            {channelId === 'feishu' && field.key === 'groupAllowFrom' && (
+              <div className="mt-2 space-y-2">
+                <p className="text-[11px] text-gray-500">
+                  当前将保存为数组 {groupAllowPreview.length > 0 ? `（${groupAllowPreview.length} 个群 ID）` : '（当前为空）'}。
+                </p>
+                {groupAllowPreview.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {groupAllowPreview.map(groupId => (
+                      <span key={groupId} className="px-2 py-1 rounded-full bg-violet-50 dark:bg-violet-900/20 text-[11px] text-violet-700 dark:text-violet-300 border border-violet-100 dark:border-violet-800/40 font-mono">
+                        {groupId}
+                      </span>
+                    ))}
+                  </div>
                 )}
               </div>
             )}
-            <button
-              type="button"
-              onClick={() => handleToggleField(channelId, field.key)}
-              className={`relative shrink-0 w-9 h-5 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-violet-500 ${currentVal ? 'bg-violet-600' : 'bg-gray-300 dark:bg-gray-600'}`}
-            >
-              <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${currentVal ? 'translate-x-4' : ''}`} />
-            </button>
-            <span className={`text-xs ${currentVal ? 'text-violet-600 dark:text-violet-400 font-medium' : 'text-gray-500'}`}>
-              {currentVal ? t.channels.opened : t.channels.closed}
-            </span>
-          </div>
-        ) : field.type === 'select' ? (
-          <div className="relative">
-            <select
-              name={field.key}
-              value={currentVal ?? ''}
-              onChange={e => handleFieldDraftChange(channelId, field, e.target.value)}
-              className={`w-full px-3.5 py-2 text-sm border rounded-lg bg-white dark:bg-gray-900 transition-all focus:ring-2 focus:ring-violet-100 dark:focus:ring-violet-900/30 focus:border-violet-500 outline-none
-                ${hasExplicitValue
-                  ? 'border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100'
-                  : 'border-gray-200 dark:border-gray-800 text-gray-400'}`}
-            >
-              <option value="">{defaultHint ? t.channels.notConfiguredWithDefault.replace('{value}', defaultHint) : t.common.notConfigured}</option>
-              {fieldOptions?.map(opt => (
-                <option key={opt} value={opt}>{opt}</option>
-              ))}
-            </select>
-          </div>
-        ) : field.type === 'textarea' ? (
-          <textarea
-            name={field.key}
-            rows={field.rows || 3}
-            value={textareaValue}
-            onChange={e => handleFieldDraftChange(channelId, field, e.target.value)}
-            placeholder={field.placeholder || t.common.notConfigured}
-            className={`w-full px-3.5 py-2 text-sm border rounded-lg bg-white dark:bg-gray-900 transition-all focus:ring-2 focus:ring-violet-100 dark:focus:ring-violet-900/30 focus:border-violet-500 outline-none resize-y
-              ${hasExplicitValue
-                ? 'border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100'
-                : 'border-gray-200 dark:border-gray-800 text-gray-400'}`}
-          />
-        ) : (
-          <div className="relative">
-            <input
-              name={field.key}
-              type={field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'}
-              value={currentVal ?? ''}
-              onChange={e => handleFieldDraftChange(channelId, field, e.target.value)}
-              placeholder={field.placeholder || t.common.notConfigured}
-              className={`w-full px-3.5 py-2 text-sm border rounded-lg bg-white dark:bg-gray-900 transition-all focus:ring-2 focus:ring-violet-100 dark:focus:ring-violet-900/30 focus:border-violet-500 outline-none
-                ${hasExplicitValue
-                  ? 'border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100'
-                  : 'border-gray-200 dark:border-gray-800 text-gray-400'}`}
-            />
-            {hasExplicitValue && (
-              <div className="absolute right-3 top-1/2 -translate-y-1/2 text-emerald-500">
-                <Check size={14} strokeWidth={3} />
-              </div>
-            )}
-          </div>
+          </>
         )}
-
-        {field.type !== 'toggle' && fieldHelp && (
-          <p className="mt-1.5 text-[11px] leading-relaxed text-gray-500 dark:text-gray-400">{fieldHelp}</p>
-        )}
-
-        {defaultHint && (
-          <p className="mt-1 text-[11px] text-gray-400">
-            {t.channels.defaultWhenUnset.replace('{value}', defaultHint)}
-          </p>
-        )}
-        {channelId === 'feishu' && field.key === 'groupAllowFrom' && (
-          <div className="mt-2 space-y-2">
-            <p className="text-[11px] text-gray-500">
-              当前将保存为数组 {groupAllowPreview.length > 0 ? `（${groupAllowPreview.length} 个群 ID）` : '（当前为空）'}。
-            </p>
-            {groupAllowPreview.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {groupAllowPreview.map(groupId => (
-                  <span key={groupId} className="px-2 py-1 rounded-full bg-violet-50 dark:bg-violet-900/20 text-[11px] text-violet-700 dark:text-violet-300 border border-violet-100 dark:border-violet-800/40 font-mono">
-                    {groupId}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      />
     );
   };
 

--- a/web/src/pages/HermesOverview.tsx
+++ b/web/src/pages/HermesOverview.tsx
@@ -37,6 +37,7 @@ export default function HermesOverview() {
   const [status, setStatus] = useState<HermesStatus | null>(null);
   const [overview, setOverview] = useState<HermesOverviewData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [storageLoading, setStorageLoading] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [msg, setMsg] = useState('');
   const [err, setErr] = useState('');
@@ -49,6 +50,15 @@ export default function HermesOverview() {
       if (overviewRes.ok) {
         setOverview(overviewRes.overview || {});
         setStatus(overviewRes.overview?.status || {});
+        setStorageLoading(true);
+        void api.getHermesStorage()
+          .then(storageRes => {
+            if (storageRes?.ok) {
+              setOverview(prev => ({ ...(prev || {}), storage: storageRes.storage || {} }));
+            }
+          })
+          .catch(() => {})
+          .finally(() => setStorageLoading(false));
       }
     } catch {
       setErr(locale === 'zh-CN' ? '加载 Hermes 状态失败' : 'Failed to load Hermes status');
@@ -104,13 +114,15 @@ export default function HermesOverview() {
       tone: status?.pythonVersion ? 'violet' : 'slate',
     },
     {
-      label: locale === 'zh-CN' ? '已配置平台' : 'Configured Platforms',
-      value: String(overview?.platforms?.configuredCount ?? 0),
-      tone: (overview?.platforms?.configuredCount ?? 0) > 0 ? 'blue' : 'slate',
+      label: locale === 'zh-CN' ? '已启用平台' : 'Enabled Platforms',
+      value: String(overview?.platforms?.enabledCount ?? 0),
+      tone: (overview?.platforms?.enabledCount ?? 0) > 0 ? 'blue' : 'slate',
     },
     {
       label: locale === 'zh-CN' ? '会话数' : 'Sessions',
-      value: String(overview?.storage?.conversationCount ?? overview?.storage?.sessionArtifactCount ?? 0),
+      value: storageLoading
+        ? (locale === 'zh-CN' ? '加载中...' : 'Loading...')
+        : String(overview?.storage?.conversationCount ?? overview?.storage?.sessionArtifactCount ?? 0),
       tone: (overview?.storage?.conversationCount ?? overview?.storage?.sessionArtifactCount ?? 0) > 0 ? 'emerald' : 'slate',
     },
   ];
@@ -178,11 +190,11 @@ export default function HermesOverview() {
           </div>
         </div>
         <div className="hidden md:flex items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
-          <span>{locale === 'zh-CN' ? '平台' : 'Platforms'} {overview?.platforms?.configuredCount ?? 0}</span>
+          <span>{locale === 'zh-CN' ? '平台' : 'Platforms'} {overview?.platforms?.enabledCount ?? 0}</span>
           <span>·</span>
           <span>{locale === 'zh-CN' ? '动作' : 'Actions'} {(overview?.actions || []).length}</span>
           <span>·</span>
-          <span>{locale === 'zh-CN' ? '会话' : 'Sessions'} {overview?.storage?.conversationCount ?? overview?.storage?.sessionArtifactCount ?? 0}</span>
+          <span>{locale === 'zh-CN' ? '会话' : 'Sessions'} {storageLoading ? '...' : (overview?.storage?.conversationCount ?? overview?.storage?.sessionArtifactCount ?? 0)}</span>
         </div>
       </div>
 
@@ -305,7 +317,7 @@ export default function HermesOverview() {
           <div className="space-y-3 text-sm text-gray-700 dark:text-gray-300">
             <div>{locale === 'zh-CN' ? 'Doctor 状态：' : 'Doctor Status: '}{overview?.doctor?.taskStatus || '-'}</div>
             <div>{locale === 'zh-CN' ? 'Doctor 时间：' : 'Doctor Updated: '}{overview?.doctor?.updatedAt || '-'}</div>
-            <div>{locale === 'zh-CN' ? '样例会话：' : 'Sample Session: '}{overview?.storage?.previewSessions?.[0]?.title || '-'}</div>
+            <div>{locale === 'zh-CN' ? '样例会话：' : 'Sample Session: '}{storageLoading ? (locale === 'zh-CN' ? '加载中...' : 'Loading...') : (overview?.storage?.previewSessions?.[0]?.title || '-')}</div>
             <div>{locale === 'zh-CN' ? '可执行动作：' : 'Available Actions: '}{(overview?.actions || []).map(item => item.label).slice(0, 3).join(' / ') || '-'}</div>
           </div>
         </div>

--- a/web/src/pages/HermesPlatforms.tsx
+++ b/web/src/pages/HermesPlatforms.tsx
@@ -1,8 +1,29 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import { api } from '../lib/api';
-import { RefreshCw, Save, Play, Wrench, Activity } from 'lucide-react';
+import { RefreshCw, Save, Play, Wrench, Activity, Check, Radio, ChevronDown } from 'lucide-react';
 import { useI18n } from '../i18n';
+import ConfigFieldRenderer from '../components/ConfigFieldRenderer';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type PlatformFieldSection = 'bot' | 'platform' | 'advanced';
+
+type PlatformConfigField = {
+  key: string;
+  label: string;
+  type: 'text' | 'password' | 'toggle' | 'number' | 'select' | 'textarea';
+  options?: string[];
+  valueFormat?: 'stringArray';
+  placeholder?: string;
+  help?: string;
+  defaultValue?: string | number | boolean;
+  section?: PlatformFieldSection;
+  rows?: number;
+  envVar?: boolean; // if true, belongs to environment vars; otherwise config.yaml
+};
 
 interface PlatformStatus {
   id: string;
@@ -19,6 +40,472 @@ interface PlatformDetail {
   status: PlatformStatus;
   config: Record<string, any>;
   environment: Record<string, string>;
+  fields?: PlatformConfigField[];
+}
+
+interface PlatformsResponse {
+  platforms?: PlatformStatus[];
+  configuredCount?: number;
+  enabledCount?: number;
+  detailsById?: Record<string, PlatformDetail>;
+}
+
+// ============================================================================
+// Platform Field Catalogs
+// ============================================================================
+
+const TELEGRAM_FIELDS: PlatformConfigField[] = [
+  // Bot Configuration (ENV)
+  {
+    key: 'TELEGRAM_BOT_TOKEN',
+    label: 'Bot Token',
+    type: 'password',
+    section: 'bot',
+    envVar: true,
+    help: 'Token from @BotFather, e.g. 123456789:ABCdefGHIjkl...',
+    placeholder: '123456789:ABCdefGHIjklMNOpqrsTUVwxyz',
+  },
+  {
+    key: 'TELEGRAM_ALLOWED_USERS',
+    label: 'Allowed Users',
+    type: 'text',
+    section: 'bot',
+    envVar: true,
+    help: 'Comma-separated Telegram user IDs. If empty, all users are denied by default.',
+    placeholder: '123456789, 987654321',
+  },
+  {
+    key: 'TELEGRAM_HOME_CHANNEL',
+    label: 'Home Channel ID',
+    type: 'text',
+    section: 'bot',
+    envVar: true,
+    help: 'Numeric chat ID for cron job delivery. Use @username for channels.',
+    placeholder: '-1001234567890',
+  },
+  {
+    key: 'TELEGRAM_HOME_CHANNEL_NAME',
+    label: 'Home Channel Name',
+    type: 'text',
+    section: 'bot',
+    envVar: true,
+    help: 'Display name for the home channel.',
+    placeholder: 'My Channel',
+  },
+  // Platform Settings (config.yaml)
+  {
+    key: 'require_mention',
+    label: 'Require @mention',
+    type: 'toggle',
+    section: 'platform',
+    envVar: false,
+    help: 'Bot only responds when @mentioned in groups. DMs are always allowed.',
+  },
+  {
+    key: 'mention_patterns',
+    label: 'Mention Patterns',
+    type: 'textarea',
+    section: 'platform',
+    envVar: false,
+    rows: 3,
+    help: 'Regex wake-word patterns (one per line or JSON array). Used when require_mention is on.',
+    placeholder: '^\\s*hermes\\b\n^\\s*hey hermes\\b',
+  },
+  {
+    key: 'free_response_chats',
+    label: 'Free Response Chats',
+    type: 'textarea',
+    section: 'platform',
+    envVar: false,
+    rows: 3,
+    help: 'Chat IDs where the bot responds without needing a @mention (one per line or JSON array).',
+    placeholder: '-1001234567890\n-1009876543210',
+  },
+  {
+    key: 'ignored_threads',
+    label: 'Ignored Threads',
+    type: 'textarea',
+    section: 'platform',
+    envVar: false,
+    rows: 3,
+    help: 'Forum topic/thread IDs where the bot never responds (one per line or JSON array).',
+    placeholder: '31\n42',
+  },
+  {
+    key: 'reactions',
+    label: 'Enable Reactions',
+    type: 'toggle',
+    section: 'platform',
+    envVar: false,
+    help: 'Show emoji reactions on messages while the agent is thinking.',
+  },
+  {
+    key: 'reply_to_mode',
+    label: 'Reply Mode',
+    type: 'select',
+    options: ['first', 'all', 'off'],
+    section: 'platform',
+    envVar: false,
+    help: 'Whether to reply to message threads. "first" replies to the first message in a thread.',
+  },
+  {
+    key: 'disable_link_previews',
+    label: 'Disable Link Previews',
+    type: 'toggle',
+    section: 'platform',
+    envVar: false,
+    help: 'Suppress Telegram link previews for URLs in bot messages.',
+  },
+  {
+    key: 'webhook_mode',
+    label: 'Webhook Mode',
+    type: 'toggle',
+    section: 'advanced',
+    envVar: false,
+    help: 'Use webhook instead of long polling. Requires TELEGRAM_WEBHOOK_URL env var.',
+  },
+  {
+    key: 'TELEGRAM_WEBHOOK_URL',
+    label: 'Webhook URL',
+    type: 'text',
+    section: 'advanced',
+    envVar: true,
+    help: 'Public HTTPS URL for webhook mode. Enables webhook instead of polling.',
+    placeholder: 'https://your-domain.com/webhook/telegram',
+  },
+  {
+    key: 'TELEGRAM_WEBHOOK_PORT',
+    label: 'Webhook Port',
+    type: 'number',
+    section: 'advanced',
+    envVar: true,
+    help: 'Local listen port for webhook server (default: 8443).',
+    placeholder: '8443',
+  },
+  {
+    key: 'TELEGRAM_WEBHOOK_SECRET',
+    label: 'Webhook Secret',
+    type: 'password',
+    section: 'advanced',
+    envVar: true,
+    help: 'Secret token for verifying that updates come from Telegram.',
+    placeholder: 'your-webhook-secret',
+  },
+  {
+    key: 'TELEGRAM_PROXY',
+    label: 'Proxy URL',
+    type: 'text',
+    section: 'advanced',
+    envVar: true,
+    help: 'Proxy URL (http://, https://, socks5://). Overrides HTTPS_PROXY.',
+    placeholder: 'socks5://127.0.0.1:1080',
+  },
+  {
+    key: 'TELEGRAM_REQUIRE_MENTION',
+    label: 'Require Mention (Legacy)',
+    type: 'toggle',
+    section: 'advanced',
+    envVar: true,
+    help: 'Legacy env var equivalent of require_mention config option.',
+  },
+  {
+    key: 'TELEGRAM_REPLY_TO_MODE',
+    label: 'Reply Mode (Legacy)',
+    type: 'select',
+    options: ['first', 'all', 'off'],
+    section: 'advanced',
+    envVar: true,
+    help: 'Legacy env var equivalent of reply_to_mode config option.',
+  },
+  {
+    key: 'TELEGRAM_FALLBACK_IPS',
+    label: 'Fallback IPs',
+    type: 'textarea',
+    section: 'advanced',
+    envVar: true,
+    rows: 3,
+    help: 'Comma-separated fallback IPs for restricted networks.',
+    placeholder: '149.154.167.220\n149.154.164.220',
+  },
+];
+
+const QQBOT_FIELDS: PlatformConfigField[] = [
+  {
+    key: 'QQ_APP_ID',
+    label: 'App ID',
+    type: 'text',
+    section: 'bot',
+    envVar: true,
+    help: 'QQ Bot App ID from q.qq.com.',
+    placeholder: '1024xxxxxx',
+  },
+  {
+    key: 'QQ_CLIENT_SECRET',
+    label: 'App Secret',
+    type: 'password',
+    section: 'bot',
+    envVar: true,
+    help: 'QQ Bot App Secret from q.qq.com.',
+    placeholder: 'your-app-secret',
+  },
+  {
+    key: 'QQ_HOME_CHANNEL',
+    label: 'Home Channel',
+    type: 'text',
+    section: 'bot',
+    envVar: true,
+    help: 'OpenID used for cron delivery and notifications.',
+    placeholder: 'user_or_group_openid',
+  },
+  {
+    key: 'QQ_HOME_CHANNEL_NAME',
+    label: 'Home Channel Name',
+    type: 'text',
+    section: 'bot',
+    envVar: true,
+    help: 'Display name for the home target.',
+    placeholder: 'Home',
+  },
+  {
+    key: 'extra.markdown_support',
+    label: 'Markdown Support',
+    type: 'toggle',
+    section: 'platform',
+    envVar: false,
+    help: 'Enable QQ markdown message format.',
+  },
+  {
+    key: 'extra.dm_policy',
+    label: 'DM Policy',
+    type: 'select',
+    options: ['open', 'allowlist', 'disabled'],
+    section: 'platform',
+    envVar: false,
+    help: 'Direct-message access policy.',
+  },
+  {
+    key: 'QQ_ALLOWED_USERS',
+    label: 'DM Allowed Users',
+    type: 'textarea',
+    section: 'platform',
+    envVar: true,
+    rows: 3,
+    help: 'Comma or newline separated QQ user OpenIDs allowed to DM the bot.',
+    placeholder: 'user_openid_1\nuser_openid_2',
+  },
+  {
+    key: 'extra.group_policy',
+    label: 'Group Policy',
+    type: 'select',
+    options: ['open', 'allowlist', 'disabled'],
+    section: 'platform',
+    envVar: false,
+    help: 'Group @-message access policy.',
+  },
+  {
+    key: 'QQ_GROUP_ALLOWED_USERS',
+    label: 'Group Allowlist',
+    type: 'textarea',
+    section: 'platform',
+    envVar: true,
+    rows: 3,
+    help: 'Comma or newline separated group OpenIDs allowed to mention the bot.',
+    placeholder: 'group_openid_1\ngroup_openid_2',
+  },
+  {
+    key: 'QQ_ALLOW_ALL_USERS',
+    label: 'Allow All Users',
+    type: 'toggle',
+    section: 'advanced',
+    envVar: true,
+    help: 'Allow all QQ users to DM the bot. Overrides DM allowlist.',
+  },
+  {
+    key: 'QQ_STT_API_KEY',
+    label: 'STT API Key',
+    type: 'password',
+    section: 'advanced',
+    envVar: true,
+    help: 'Optional voice-to-text API key when QQ built-in ASR is unavailable.',
+    placeholder: 'stt-api-key',
+  },
+  {
+    key: 'QQ_STT_BASE_URL',
+    label: 'STT Base URL',
+    type: 'text',
+    section: 'advanced',
+    envVar: true,
+    help: 'Optional OpenAI-compatible STT endpoint.',
+    placeholder: 'https://open.bigmodel.cn/api/coding/paas/v4',
+  },
+  {
+    key: 'QQ_STT_MODEL',
+    label: 'STT Model',
+    type: 'text',
+    section: 'advanced',
+    envVar: true,
+    help: 'Voice transcription model name.',
+    placeholder: 'glm-asr',
+  },
+];
+
+const DISCORD_FIELDS: PlatformConfigField[] = [
+  { key: 'DISCORD_BOT_TOKEN', label: 'Bot Token', type: 'password', section: 'bot', envVar: true, help: 'Discord Bot Token。' },
+  { key: 'DISCORD_ALLOWED_USERS', label: '私聊白名单', type: 'textarea', rows: 3, section: 'platform', envVar: true, valueFormat: 'stringArray', help: '允许与 Bot 私聊的用户 ID，支持逗号或换行分隔。' },
+  { key: 'DISCORD_HOME_CHANNEL', label: 'Home Channel', type: 'text', section: 'platform', envVar: true, help: '用于通知和定时任务投递的频道 ID。' },
+];
+
+const SLACK_FIELDS: PlatformConfigField[] = [
+  { key: 'SLACK_APP_TOKEN', label: 'App Token', type: 'password', section: 'bot', envVar: true, help: 'Slack App Level Token，通常以 xapp- 开头。' },
+  { key: 'SLACK_BOT_TOKEN', label: 'Bot Token', type: 'password', section: 'bot', envVar: true, help: 'Slack Bot User OAuth Token，通常以 xoxb- 开头。' },
+  { key: 'SLACK_ALLOWED_USERS', label: '私聊白名单', type: 'textarea', rows: 3, section: 'platform', envVar: true, valueFormat: 'stringArray', help: '允许触发 Bot 的 Slack 用户 ID。' },
+  { key: 'SLACK_HOME_CHANNEL', label: 'Home Channel', type: 'text', section: 'platform', envVar: true, help: '通知与 cron 消息投递频道。' },
+];
+
+const SIGNAL_FIELDS: PlatformConfigField[] = [
+  { key: 'SIGNAL_ALLOWED_USERS', label: '私聊白名单', type: 'textarea', rows: 3, section: 'platform', envVar: true, valueFormat: 'stringArray', help: '允许触发 Bot 的 Signal 用户。' },
+  { key: 'SIGNAL_HOME_CONTACT', label: 'Home Contact', type: 'text', section: 'platform', envVar: true, help: '用于通知和定时消息投递的 Signal 联系人。' },
+];
+
+const WHATSAPP_FIELDS: PlatformConfigField[] = [
+  { key: 'WHATSAPP_ALLOWED_USERS', label: '私聊白名单', type: 'textarea', rows: 3, section: 'platform', envVar: true, valueFormat: 'stringArray', help: '允许触发 Bot 的 WhatsApp 用户。' },
+  { key: 'WHATSAPP_HOME_CONTACT', label: 'Home Contact', type: 'text', section: 'platform', envVar: true, help: '用于通知和定时消息投递的联系人。' },
+];
+
+const FEISHU_FIELDS: PlatformConfigField[] = [
+  { key: 'FEISHU_APP_ID', label: 'App ID', type: 'text', section: 'bot', envVar: true, help: '飞书 / Lark 应用 App ID。' },
+  { key: 'FEISHU_APP_SECRET', label: 'App Secret', type: 'password', section: 'bot', envVar: true, help: '飞书 / Lark 应用 App Secret。' },
+];
+
+const WECOM_FIELDS: PlatformConfigField[] = [
+  { key: 'WECOM_BOT_ID', label: 'Bot ID', type: 'text', section: 'bot', envVar: true, help: '企业微信长连接模式 Bot ID。' },
+  { key: 'WECOM_SECRET', label: 'Secret', type: 'password', section: 'bot', envVar: true, help: '企业微信 Secret。' },
+  { key: 'WECOM_ALLOWED_USERS', label: '私聊白名单', type: 'textarea', rows: 3, section: 'platform', envVar: true, valueFormat: 'stringArray', help: '允许触发 Bot 的企业微信用户。' },
+  { key: 'WECOM_HOME_CHANNEL', label: 'Home Channel', type: 'text', section: 'platform', envVar: true, help: '通知和 cron 投递目标。' },
+  { key: 'WECOM_HOME_CHANNEL_NAME', label: 'Home Channel Name', type: 'text', section: 'platform', envVar: true, help: 'Home Channel 显示名称。' },
+];
+
+const WEIXIN_FIELDS: PlatformConfigField[] = [
+  { key: 'WEIXIN_ACCOUNT_ID', label: 'Account ID', type: 'text', section: 'bot', envVar: true, help: '微信接入账户 ID。' },
+  { key: 'WEIXIN_TOKEN', label: 'Token', type: 'password', section: 'bot', envVar: true, help: '微信接入 Token。' },
+  { key: 'WEIXIN_ALLOWED_USERS', label: '私聊白名单', type: 'textarea', rows: 3, section: 'platform', envVar: true, valueFormat: 'stringArray', help: '允许触发 Bot 的微信用户。' },
+  { key: 'WEIXIN_HOME_CHANNEL', label: 'Home Channel', type: 'text', section: 'platform', envVar: true, help: '通知和 cron 投递目标。' },
+  { key: 'WEIXIN_HOME_CHANNEL_NAME', label: 'Home Channel Name', type: 'text', section: 'platform', envVar: true, help: 'Home Channel 显示名称。' },
+];
+
+const DINGTALK_FIELDS: PlatformConfigField[] = [
+  { key: 'DINGTALK_APP_KEY', label: 'App Key', type: 'text', section: 'bot', envVar: true, help: '钉钉应用 App Key。' },
+  { key: 'DINGTALK_APP_SECRET', label: 'App Secret', type: 'password', section: 'bot', envVar: true, help: '钉钉应用 App Secret。' },
+];
+
+const MATRIX_FIELDS: PlatformConfigField[] = [
+  { key: 'MATRIX_HOMESERVER_URL', label: 'Homeserver URL', type: 'text', section: 'bot', envVar: true, help: 'Matrix homeserver 地址。' },
+  { key: 'MATRIX_ACCESS_TOKEN', label: 'Access Token', type: 'password', section: 'bot', envVar: true, help: 'Matrix Access Token。' },
+];
+
+const WEBHOOK_FIELDS: PlatformConfigField[] = [
+  { key: 'WEBHOOK_PORT', label: 'Webhook Port', type: 'number', section: 'advanced', envVar: true, help: 'Webhook 监听端口。' },
+  { key: 'WEBHOOK_SECRET', label: 'Webhook Secret', type: 'password', section: 'advanced', envVar: true, help: 'Webhook 签名 Secret。' },
+];
+
+const SMS_FIELDS: PlatformConfigField[] = [
+  { key: 'TWILIO_ACCOUNT_SID', label: 'Twilio Account SID', type: 'text', section: 'bot', envVar: true, help: 'Twilio Account SID。' },
+  { key: 'TWILIO_AUTH_TOKEN', label: 'Twilio Auth Token', type: 'password', section: 'bot', envVar: true, help: 'Twilio Auth Token。' },
+  { key: 'TWILIO_FROM_NUMBER', label: 'From Number', type: 'text', section: 'platform', envVar: true, help: 'Twilio 发信号码。' },
+];
+
+const PLATFORM_CATALOG: Record<string, PlatformConfigField[]> = {
+  telegram: TELEGRAM_FIELDS,
+  qqbot: QQBOT_FIELDS,
+  discord: DISCORD_FIELDS,
+  slack: SLACK_FIELDS,
+  signal: SIGNAL_FIELDS,
+  whatsapp: WHATSAPP_FIELDS,
+  feishu: FEISHU_FIELDS,
+  wecom: WECOM_FIELDS,
+  weixin: WEIXIN_FIELDS,
+  dingtalk: DINGTALK_FIELDS,
+  matrix: MATRIX_FIELDS,
+  webhook: WEBHOOK_FIELDS,
+  sms: SMS_FIELDS,
+};
+
+const SECTION_META: Record<PlatformFieldSection, { title: string; titleZh: string }> = {
+  bot: {
+    title: 'Bot Configuration',
+    titleZh: '机器人配置',
+  },
+  platform: {
+    title: 'Platform Settings',
+    titleZh: '平台设置',
+  },
+  advanced: {
+    title: 'Advanced',
+    titleZh: '高级选项',
+  },
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function parseDelimitedList(value: string | undefined | null): string[] {
+  if (!value) return [];
+  return value.split(/[\n,]+/).map(s => s.trim()).filter(Boolean);
+}
+
+function formatDelimitedList(values: string[] | undefined | null): string {
+  if (!values || !Array.isArray(values)) return '';
+  return values.join(', ');
+}
+
+function getPlatformStatusKey(platform: PlatformStatus): 'enabled' | 'configured' | 'unconfigured' {
+  if (platform.enabled || platform.runtimeStatus === 'healthy' || platform.runtimeStatus === 'warning' || platform.runtimeStatus === 'error') return 'enabled';
+  if (platform.configured) return 'configured';
+  return 'unconfigured';
+}
+
+function statusDotClass(status: 'enabled' | 'configured' | 'unconfigured') {
+  if (status === 'enabled') return 'bg-emerald-500';
+  if (status === 'configured') return 'bg-red-400';
+  return 'bg-gray-300';
+}
+
+function getNestedValue(obj: Record<string, any> | null, key: string): any {
+  if (!obj) return undefined;
+  return key.split('.').reduce((o: any, k) => o?.[k], obj);
+}
+
+function setNestedValue(obj: Record<string, any>, key: string, value: any): void {
+  const parts = key.split('.');
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (!(p in current)) current[p] = {};
+    current = current[p];
+  }
+  const last = parts[parts.length - 1];
+  if (value === undefined || value === null || value === '') {
+    delete current[last];
+  } else {
+    current[last] = value;
+  }
+}
+
+function deleteNestedValue(obj: Record<string, any>, key: string): void {
+  const parts = key.split('.');
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (!(p in current)) return;
+    current = current[p];
+  }
+  const last = parts[parts.length - 1];
+  delete current[last];
+}
+
+function isPlainObject(value: any): boolean {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function envToText(env: Record<string, string>) {
@@ -39,22 +526,49 @@ function textToEnv(text: string) {
   return result;
 }
 
+// ============================================================================
+// Component
+// ============================================================================
+
 export default function HermesPlatforms() {
   const { locale } = useI18n();
   const { uiMode } = (useOutletContext() as { uiMode?: 'modern' }) || {};
   const navigate = useNavigate();
   const modern = uiMode === 'modern';
+
   const [platforms, setPlatforms] = useState<PlatformStatus[]>([]);
   const [selectedId, setSelectedId] = useState('');
   const [detail, setDetail] = useState<PlatformDetail | null>(null);
-  const [configText, setConfigText] = useState('{}');
-  const [envText, setEnvText] = useState('');
+  const [detailCache, setDetailCache] = useState<Record<string, PlatformDetail>>({});
+
+  // Structured drafts
+  const [envDrafts, setEnvDrafts] = useState<Record<string, string>>({});
+  const [configDrafts, setConfigDrafts] = useState<Record<string, any>>({});
+
   const [enabled, setEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState('');
   const [err, setErr] = useState('');
   const [actionRunning, setActionRunning] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const platformFields = (PLATFORM_CATALOG[selectedId] && PLATFORM_CATALOG[selectedId].length > 0)
+    ? PLATFORM_CATALOG[selectedId]
+    : (detail?.fields || []);
+
+  const applyDetail = (platform: PlatformDetail | null) => {
+    setDetail(platform);
+    setEnabled(Boolean(platform?.status?.enabled));
+
+    const envMap: Record<string, string> = {};
+    for (const [k, v] of Object.entries(platform?.environment || {})) {
+      envMap[k] = String(v ?? '');
+    }
+    setEnvDrafts(envMap);
+    setConfigDrafts({ ...(platform?.config || {}) });
+  };
 
   const loadPlatforms = async () => {
     setLoading(true);
@@ -62,9 +576,19 @@ export default function HermesPlatforms() {
     try {
       const r = await api.getHermesPlatforms();
       if (r.ok) {
-        const next = r.platforms?.platforms || [];
+        const platformPayload = (r.platforms || {}) as PlatformsResponse;
+        const next = platformPayload.platforms || [];
+        const nextSelectedId = selectedId || next[0]?.id || '';
         setPlatforms(next);
-        setSelectedId(prev => prev || next[0]?.id || '');
+        setSelectedId(prev => prev || nextSelectedId);
+
+        const embeddedDetails = platformPayload.detailsById || {};
+        if (Object.keys(embeddedDetails).length > 0) {
+          setDetailCache(prev => ({ ...prev, ...embeddedDetails }));
+          if (nextSelectedId && embeddedDetails[nextSelectedId]) {
+            applyDetail(embeddedDetails[nextSelectedId]);
+          }
+        }
       }
     } catch {
       setErr(locale === 'zh-CN' ? '加载 Hermes 平台失败' : 'Failed to load Hermes platforms');
@@ -75,21 +599,71 @@ export default function HermesPlatforms() {
 
   const loadDetail = async (id: string) => {
     if (!id) return;
+    if (detailCache[id]) {
+      applyDetail(detailCache[id]);
+      return;
+    }
+    setDetail(null);
+    setDetailLoading(true);
     try {
       const r = await api.getHermesPlatformDetail(id);
       if (r.ok) {
-        setDetail(r.platform || null);
-        setEnabled(Boolean(r.platform?.status?.enabled));
-        setConfigText(JSON.stringify(r.platform?.config || {}, null, 2));
-        setEnvText(envToText(r.platform?.environment || {}));
+        const platform = r.platform || null;
+        if (platform) {
+          setDetailCache(prev => ({ ...prev, [id]: platform }));
+        }
+        applyDetail(platform);
       }
     } catch {
       setErr(locale === 'zh-CN' ? '加载 Hermes 平台详情失败' : 'Failed to load Hermes platform detail');
+    } finally {
+      setDetailLoading(false);
     }
   };
 
   useEffect(() => { loadPlatforms(); }, []);
   useEffect(() => { if (selectedId) loadDetail(selectedId); }, [selectedId]);
+  useEffect(() => { setAdvancedOpen(false); }, [selectedId]);
+
+  // --------------------------------------------------------------------------
+  // Field value accessors
+  // --------------------------------------------------------------------------
+
+  const getEnvValue = (key: string): string => {
+    return envDrafts[key] ?? '';
+  };
+
+  const getConfigValue = (key: string): any => {
+    return getNestedValue(configDrafts, key);
+  };
+
+  const handleEnvChange = (key: string, value: string) => {
+    setEnvDrafts(prev => {
+      const next = { ...prev };
+      if (value.trim()) {
+        next[key] = value;
+      } else {
+        delete next[key];
+      }
+      return next;
+    });
+  };
+
+  const handleConfigChange = (key: string, value: any) => {
+    setConfigDrafts(prev => {
+      const next = { ...prev };
+      setNestedValue(next, key, value);
+      return next;
+    });
+  };
+
+  const handleToggle = (key: string) => {
+    handleConfigChange(key, !getConfigValue(key));
+  };
+
+  // --------------------------------------------------------------------------
+  // Save
+  // --------------------------------------------------------------------------
 
   const save = async () => {
     if (!selectedId) return;
@@ -97,22 +671,30 @@ export default function HermesPlatforms() {
     setErr('');
     setMsg('');
     try {
-      const parsed = JSON.parse(configText || '{}');
-      const env = textToEnv(envText);
-      const r = await api.updateHermesPlatformDetail(selectedId, { enabled, config: parsed, env });
+      const env = { ...envDrafts };
+      const r = await api.updateHermesPlatformDetail(selectedId, { enabled, config: configDrafts, env });
       if (r.ok) {
         setMsg(locale === 'zh-CN' ? '平台配置已保存' : 'Platform configuration saved');
+        setDetailCache(prev => {
+          const next = { ...prev };
+          delete next[selectedId];
+          return next;
+        });
         await loadPlatforms();
         await loadDetail(selectedId);
       } else {
         setErr(r.error || 'Save failed');
       }
     } catch (e) {
-      setErr(locale === 'zh-CN' ? `配置格式错误: ${String(e)}` : `Invalid config format: ${String(e)}`);
+      setErr(locale === 'zh-CN' ? `保存失败: ${String(e)}` : `Save failed: ${String(e)}`);
     } finally {
       setSaving(false);
     }
   };
+
+  // --------------------------------------------------------------------------
+  // Actions
+  // --------------------------------------------------------------------------
 
   const runAction = async (action: string) => {
     setActionRunning(true);
@@ -132,15 +714,93 @@ export default function HermesPlatforms() {
     }
   };
 
+  // --------------------------------------------------------------------------
+  // Field renderer
+  // --------------------------------------------------------------------------
+
+  const renderField = (field: PlatformConfigField) => {
+    const isEnv = field.envVar !== false;
+    const currentVal = isEnv ? getEnvValue(field.key) : getConfigValue(field.key);
+    const hasExplicitValue = currentVal !== undefined && currentVal !== null && currentVal !== '';
+
+    const handleChange = (rawValue: string) => {
+      if (isEnv) {
+        if (field.valueFormat === 'stringArray') {
+          handleEnvChange(field.key, parseDelimitedList(rawValue).join(','));
+        } else {
+          handleEnvChange(field.key, rawValue);
+        }
+      } else {
+        if (field.type === 'number') {
+          const parsed = Number(rawValue);
+          handleConfigChange(field.key, Number.isFinite(parsed) ? parsed : rawValue);
+        } else if (field.valueFormat === 'stringArray') {
+          handleConfigChange(field.key, parseDelimitedList(rawValue));
+        } else {
+          handleConfigChange(field.key, rawValue);
+        }
+      }
+    };
+
+    const textDraftKey = `${field.key}`;
+    const textareaValue = field.type === 'textarea'
+      ? (field.valueFormat === 'stringArray'
+        ? (Array.isArray(currentVal) ? currentVal.join('\n') : String(currentVal ?? '').replace(/,/g, '\n'))
+        : currentVal ?? '')
+      : '';
+
+    const showCheck = hasExplicitValue && field.type !== 'toggle';
+
+    return (
+      <ConfigFieldRenderer
+        key={field.key}
+        field={field}
+        value={currentVal}
+        textareaValue={textareaValue}
+        hasExplicitValue={showCheck}
+        onChange={handleChange}
+        onToggle={() => handleToggle(field.key)}
+        fieldHelp={field.help}
+        emptyOptionLabel={field.placeholder || (locale === 'zh-CN' ? '未配置' : 'Not configured')}
+        accent="violet"
+      />
+    );
+  };
+
+  const botFields = platformFields.filter(f => f.section === 'bot');
+  const platformFields_ = platformFields.filter(f => f.section === 'platform');
+  const advancedFields = platformFields.filter(f => f.section === 'advanced');
+
+  const mainFieldGroups: { section: PlatformFieldSection; fields: PlatformConfigField[] }[] = [
+    { section: 'bot' as PlatformFieldSection, fields: botFields },
+    { section: 'platform' as PlatformFieldSection, fields: platformFields_ },
+  ].filter(g => g.fields.length > 0);
+
+  const sortedPlatforms = [...platforms].sort((a, b) => {
+    const order = { enabled: 0, configured: 1, unconfigured: 2 };
+    return order[getPlatformStatusKey(a)] - order[getPlatformStatusKey(b)] || a.label.localeCompare(b.label);
+  });
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
   return (
     <div className={`space-y-6 ${modern ? 'page-modern' : ''}`}>
       <div className={`${modern ? 'page-modern-header' : 'flex items-center justify-between'}`}>
         <div>
-          <h2 className={`${modern ? 'page-modern-title text-xl' : 'text-xl font-bold text-gray-900 dark:text-white'}`}>{locale === 'zh-CN' ? 'Hermes 平台管理' : 'Hermes Platforms'}</h2>
+          <h2 className={`${modern ? 'page-modern-title text-xl' : 'text-xl font-bold text-gray-900 dark:text-white'}`}>
+            {locale === 'zh-CN' ? 'Hermes 平台管理' : 'Hermes Platforms'}
+          </h2>
           <p className={`${modern ? 'page-modern-subtitle mt-1 text-sm' : 'text-sm text-gray-500 mt-1'}`}>
             {locale === 'zh-CN'
-              ? '查看各平台的配置、启用状态和运行线索，并做最小配置编辑。'
-              : 'Review platform state, config, and runtime evidence, then apply minimal updates.'}
+              ? '配置 Hermes 消息平台的机器人凭证和运行参数。'
+              : 'Configure Hermes messaging platform bot credentials and runtime parameters.'}
+          </p>
+          <p className="text-xs text-gray-500 mt-1.5 inline-flex items-center gap-3 flex-wrap">
+            <span className="inline-flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-emerald-500 inline-block" />{locale === 'zh-CN' ? '已启用/运行态' : 'Enabled / active'}</span>
+            <span className="inline-flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-red-400 inline-block" />{locale === 'zh-CN' ? '已配置未启用' : 'Configured'}</span>
+            <span className="inline-flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-gray-300 inline-block" />{locale === 'zh-CN' ? '未配置' : 'Unconfigured'}</span>
           </p>
         </div>
         <button onClick={loadPlatforms} className={`${modern ? 'page-modern-action px-3 py-2 text-xs' : 'px-3 py-2 text-xs rounded-lg bg-gray-100 dark:bg-gray-800'} inline-flex items-center gap-2`}>
@@ -152,76 +812,175 @@ export default function HermesPlatforms() {
       {msg && <div className="rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/30 dark:bg-emerald-900/10 dark:text-emerald-300">{msg}</div>}
       {err && <div className="rounded-2xl border border-red-100 bg-red-50/80 px-4 py-3 text-sm text-red-700 dark:border-red-900/30 dark:bg-red-900/10 dark:text-red-300">{err}</div>}
 
-      <div className="grid grid-cols-1 xl:grid-cols-[360px_1fr] gap-6">
-        <div className={`${modern ? 'page-modern-panel' : 'bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700/50'} rounded-2xl p-4 space-y-3`}>
-          {platforms.map(platform => (
-            <button key={platform.id} onClick={() => setSelectedId(platform.id)} className={`w-full text-left rounded-xl border px-4 py-3 transition-colors ${selectedId === platform.id ? 'border-blue-300 bg-blue-50/70 dark:border-blue-700 dark:bg-blue-900/20' : 'border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-900/40'}`}>
-              <div className="flex items-center justify-between gap-3">
-                <div className="font-medium text-gray-900 dark:text-white">{platform.label}</div>
-                <div className="text-[10px] uppercase tracking-wider text-gray-500">{platform.runtimeStatus || 'unknown'}</div>
+      <div className="grid grid-cols-1 xl:grid-cols-[320px_1fr] gap-6">
+        {/* Platform list */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/50 flex flex-col max-h-[75vh] overflow-hidden">
+          <div className="p-3 border-b border-gray-100 dark:border-gray-700/50 bg-gray-50/50 dark:bg-gray-800/50">
+            <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider px-1">{locale === 'zh-CN' ? '平台列表' : 'Platform List'}</h3>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2 space-y-1">
+          {sortedPlatforms.map(platform => {
+            const status = getPlatformStatusKey(platform);
+            return (
+            <button
+              key={platform.id}
+              onClick={() => setSelectedId(platform.id)}
+              className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left text-sm transition-all duration-200 group ${selectedId === platform.id ? 'border border-blue-100/80 bg-[linear-gradient(135deg,rgba(37,99,235,0.12),rgba(14,165,233,0.08))] dark:bg-[linear-gradient(135deg,rgba(37,99,235,0.2),rgba(14,165,233,0.12))] dark:border-blue-800/40 text-blue-700 dark:text-blue-300 shadow-sm' : 'text-gray-600 dark:text-gray-400 hover:bg-white/70 dark:hover:bg-gray-700/50 hover:border-blue-100/70'}`}
+            >
+              <div className={`p-1.5 rounded-xl transition-colors border ${selectedId === platform.id ? 'bg-blue-50/90 dark:bg-blue-900/30 border-blue-100 dark:border-blue-800/40 text-blue-600' : 'bg-gray-100 dark:bg-gray-700 border-transparent text-gray-500 group-hover:bg-white group-hover:border-blue-100/70 group-hover:shadow-sm'}`}>
+                <Radio size={14} />
               </div>
-              <div className="mt-1 text-xs text-gray-500">{platform.detail || '-'}</div>
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-semibold truncate text-gray-900 dark:text-white">{platform.label}</div>
+                <div className="text-[10px] text-gray-400 truncate opacity-80">{platform.detail || '-'}</div>
+              </div>
+              <span className={`w-2 h-2 rounded-full shrink-0 ${statusDotClass(status)} ring-2 ring-white dark:ring-gray-800`} />
             </button>
-          ))}
+          );})}
+          </div>
         </div>
 
-        <div className={`${modern ? 'page-modern-panel' : 'bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700/50'} rounded-2xl p-5 space-y-4`}>
-          {!detail ? (
-            <div className="text-sm text-gray-500">{locale === 'zh-CN' ? '请选择一个平台' : 'Select a platform'}</div>
+        {/* Platform detail / form */}
+        <div className={`${modern ? 'page-modern-panel' : 'bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700/50'} rounded-2xl p-5 space-y-6`}>
+          {!detail && !detailLoading ? (
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/50 p-10 md:p-14">
+              <div className="mx-auto max-w-xl text-center space-y-4">
+                <div className="mx-auto w-14 h-14 rounded-2xl bg-blue-50 dark:bg-blue-900/20 border border-blue-100 dark:border-blue-800/40 text-blue-500 flex items-center justify-center">
+                  <Radio size={24} />
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{locale === 'zh-CN' ? '请选择左侧平台开始配置' : 'Select a platform to configure'}</h3>
+                <p className="text-sm text-gray-500 leading-relaxed">
+                  {locale === 'zh-CN' ? '这里会显示对应平台的启用状态、运行线索和机器人参数。建议先配置基础凭证，再按需展开高级选项。' : 'This area shows platform status, runtime hints, and bot parameters. Configure basic credentials first, then expand advanced options as needed.'}
+                </p>
+              </div>
+            </div>
+          ) : detailLoading && !detail ? (
+            <div className="space-y-6 animate-pulse">
+              <div className="flex items-center justify-between gap-3">
+                <div className="space-y-2 flex-1">
+                  <div className="h-6 w-40 rounded bg-gray-200 dark:bg-gray-700" />
+                  <div className="h-4 w-3/4 rounded bg-gray-100 dark:bg-gray-800" />
+                </div>
+                <div className="flex gap-2">
+                  <div className="h-9 w-20 rounded-lg bg-gray-100 dark:bg-gray-800" />
+                  <div className="h-9 w-24 rounded-lg bg-gray-100 dark:bg-gray-800" />
+                  <div className="h-9 w-20 rounded-lg bg-gray-100 dark:bg-gray-800" />
+                </div>
+              </div>
+              <div className="h-5 w-36 rounded bg-gray-100 dark:bg-gray-800" />
+              <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+                <div className="h-20 rounded-xl bg-gray-100 dark:bg-gray-800" />
+                <div className="h-20 rounded-xl bg-gray-100 dark:bg-gray-800" />
+              </div>
+              {[1, 2].map(section => (
+                <div key={section} className="space-y-4">
+                  <div className="h-5 w-28 rounded bg-gray-200 dark:bg-gray-700" />
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="h-20 rounded-xl bg-gray-100 dark:bg-gray-800" />
+                    <div className="h-20 rounded-xl bg-gray-100 dark:bg-gray-800" />
+                    <div className="h-20 rounded-xl bg-gray-100 dark:bg-gray-800 md:col-span-2" />
+                  </div>
+                </div>
+              ))}
+            </div>
           ) : (
             <>
+              {/* Header */}
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-lg font-semibold text-gray-900 dark:text-white">{detail.status.label}</div>
-                  <div className="text-xs text-gray-500 mt-1">{detail.status.detail || '-'}</div>
+                  <div className="text-lg font-semibold text-gray-900 dark:text-white">{detail!.status.label}</div>
+                  <div className="text-xs text-gray-500 mt-1">{detail!.status.detail || '-'}</div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   <button onClick={() => navigate('/hermes/health')} className={`${modern ? 'page-modern-action px-3 py-2 text-xs' : 'px-3 py-2 text-xs rounded-lg bg-gray-100 dark:bg-gray-800'}`}>
                     {locale === 'zh-CN' ? '查看健康' : 'Health'}
                   </button>
-                  <button onClick={() => runAction(enabled ? 'gateway-restart' : 'gateway-start')} disabled={actionRunning} className={`${modern ? 'page-modern-action px-3 py-2 text-xs disabled:opacity-50' : 'px-3 py-2 text-xs rounded-lg bg-gray-100 dark:bg-gray-800 disabled:opacity-50'} inline-flex items-center gap-2`}>
+                  <button
+                    onClick={() => runAction(enabled ? 'gateway-restart' : 'gateway-start')}
+                    disabled={actionRunning}
+                    className={`${modern ? 'page-modern-action px-3 py-2 text-xs disabled:opacity-50' : 'px-3 py-2 text-xs rounded-lg bg-gray-100 dark:bg-gray-800 disabled:opacity-50'} inline-flex items-center gap-2`}
+                  >
                     {enabled ? <Activity size={14} /> : <Play size={14} />}
                     {enabled ? (locale === 'zh-CN' ? '重启网关' : 'Restart') : (locale === 'zh-CN' ? '启动网关' : 'Start')}
                   </button>
-                  <button onClick={() => runAction('doctor')} disabled={actionRunning} className={`${modern ? 'page-modern-action px-3 py-2 text-xs disabled:opacity-50' : 'px-3 py-2 text-xs rounded-lg bg-gray-100 dark:bg-gray-800 disabled:opacity-50'} inline-flex items-center gap-2`}>
+                  <button
+                    onClick={() => runAction('doctor')}
+                    disabled={actionRunning}
+                    className={`${modern ? 'page-modern-action px-3 py-2 text-xs disabled:opacity-50' : 'px-3 py-2 text-xs rounded-lg bg-gray-100 dark:bg-gray-800 disabled:opacity-50'} inline-flex items-center gap-2`}
+                  >
                     <Wrench size={14} />
                     Doctor
                   </button>
-                  <button onClick={save} disabled={saving} className={`${modern ? 'page-modern-accent px-4 py-2 text-xs disabled:opacity-50' : 'px-4 py-2 text-xs rounded-lg bg-blue-600 text-white disabled:opacity-50'} inline-flex items-center gap-2`}>
+                  <button
+                    onClick={save}
+                    disabled={saving}
+                    className={`${modern ? 'page-modern-accent px-4 py-2 text-xs disabled:opacity-50' : 'px-4 py-2 text-xs rounded-lg bg-blue-600 text-white disabled:opacity-50'} inline-flex items-center gap-2`}
+                  >
                     <Save size={14} />
                     {locale === 'zh-CN' ? '保存' : 'Save'}
                   </button>
                 </div>
               </div>
 
-              <label className="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                <input type="checkbox" checked={enabled} onChange={e => setEnabled(e.target.checked)} />
+              {/* Enable toggle */}
+              <label className="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={e => setEnabled(e.target.checked)}
+                  className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
                 {locale === 'zh-CN' ? '启用该平台' : 'Enable this platform'}
               </label>
 
-              {(detail.status.lastEvidence || detail.status.lastError) && (
+              {/* Runtime info */}
+              {(detail!.status.lastEvidence || detail!.status.lastError) && (
                 <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
                   <div className="rounded-xl border border-gray-100 dark:border-gray-700/50 bg-gray-50/70 dark:bg-gray-900/40 px-4 py-3 text-sm">
                     <div className="text-[11px] uppercase tracking-wider text-gray-500">{locale === 'zh-CN' ? '最近线索' : 'Last Evidence'}</div>
-                    <div className="mt-1 text-gray-800 dark:text-gray-100">{detail.status.lastEvidence || '-'}</div>
+                    <div className="mt-1 text-gray-800 dark:text-gray-100">{detail!.status.lastEvidence || '-'}</div>
                   </div>
                   <div className="rounded-xl border border-gray-100 dark:border-gray-700/50 bg-gray-50/70 dark:bg-gray-900/40 px-4 py-3 text-sm">
                     <div className="text-[11px] uppercase tracking-wider text-gray-500">{locale === 'zh-CN' ? '最近错误' : 'Last Error'}</div>
-                    <div className="mt-1 text-red-600 dark:text-red-300">{detail.status.lastError || '-'}</div>
+                    <div className="mt-1 text-red-600 dark:text-red-300">{detail!.status.lastError || '-'}</div>
                   </div>
                 </div>
               )}
 
-              <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <div className="text-xs font-semibold uppercase tracking-wider text-gray-500">Config JSON</div>
-                  <textarea value={configText} onChange={e => setConfigText(e.target.value)} className="w-full min-h-[320px] rounded-2xl border border-gray-100 dark:border-gray-700/50 bg-gray-50/70 dark:bg-gray-900/40 p-4 text-xs font-mono text-gray-800 dark:text-gray-100 outline-none" />
+              {/* Structured form fields */}
+              {mainFieldGroups.map(({ section, fields }) => (
+                <div key={section} className="space-y-4">
+                  <div className="border-b border-gray-100 dark:border-gray-700/50 pb-2">
+                    <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                      {locale === 'zh-CN' ? SECTION_META[section].titleZh : SECTION_META[section].title}
+                    </h3>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {fields.map(renderField)}
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <div className="text-xs font-semibold uppercase tracking-wider text-gray-500">ENV</div>
-                  <textarea value={envText} onChange={e => setEnvText(e.target.value)} className="w-full min-h-[320px] rounded-2xl border border-gray-100 dark:border-gray-700/50 bg-gray-50/70 dark:bg-gray-900/40 p-4 text-xs font-mono text-gray-800 dark:text-gray-100 outline-none" />
+              ))}
+
+              {advancedFields.length > 0 && (
+                <div className="rounded-xl border border-gray-100 dark:border-gray-700/50 overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setAdvancedOpen(prev => !prev)}
+                    className="w-full flex items-center justify-between px-4 py-3 text-left bg-gray-50/60 dark:bg-gray-900/30 hover:bg-gray-100/70 dark:hover:bg-gray-900/50"
+                  >
+                    <div>
+                      <div className="text-sm font-semibold text-gray-900 dark:text-white">{locale === 'zh-CN' ? '高级配置' : 'Advanced Configuration'}</div>
+                      <div className="text-[11px] text-gray-500 mt-0.5">{locale === 'zh-CN' ? '按需展开 webhook、STT、兼容性等选项。' : 'Expand optional webhook, STT, and compatibility settings.'}</div>
+                    </div>
+                    <ChevronDown size={16} className={`text-gray-400 transition-transform ${advancedOpen ? 'rotate-180' : ''}`} />
+                  </button>
+                  {advancedOpen && (
+                    <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4 border-t border-gray-100 dark:border-gray-700/50">
+                      {advancedFields.map(renderField)}
+                    </div>
+                  )}
                 </div>
-              </div>
+              )}
             </>
           )}
         </div>

--- a/web/src/pages/SystemConfig.tsx
+++ b/web/src/pages/SystemConfig.tsx
@@ -349,7 +349,6 @@ export default function SystemConfig() {
   const [selectedIdentityDoc, setSelectedIdentityDoc] = useState<any>(null);
   const [identityContent, setIdentityContent] = useState('');
   const [identitySaving, setIdentitySaving] = useState(false);
-  const [adminToken, setAdminToken] = useState('');
   const [checking, setChecking] = useState(false);
   const [configIssues, setConfigIssues] = useState<any[]>([]);
   const [configChecked, setConfigChecked] = useState(0);
@@ -468,10 +467,6 @@ export default function SystemConfig() {
     }
   };
 
-  const loadAdminToken = async () => {
-    const r = await api.getAdminToken();
-    if (r.ok) setAdminToken(r.token || '');
-  };
 
   const loadConfigCheck = async () => {
     setConfigCheckLoading(true);
@@ -515,7 +510,7 @@ export default function SystemConfig() {
   useEffect(() => {
     if (tab === 'version') loadVersion();
     if (tab === 'env') loadEnv();
-    if (tab === 'identity') { loadIdentityDocs(); loadAdminToken(); }
+    if (tab === 'identity') { loadIdentityDocs(); }
     if (tab === 'health') loadConfigCheck();
   }, [tab]);
 
@@ -1433,69 +1428,6 @@ export default function SystemConfig() {
       {/* === Identity & Messages Tab === */}
       {tab === 'identity' && (
         <div className="space-y-6 animate-in fade-in slide-in-from-top-4 duration-200">
-          <div className={`${modern ? 'page-modern-panel p-6' : 'bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/50 p-6'} space-y-5`}>
-            <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-2xl bg-blue-100/80 dark:bg-blue-900/20 text-blue-600 border border-blue-100/70 dark:border-blue-800/30">
-                    <Key size={18} />
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-bold text-gray-900 dark:text-white">管理后台登录与身份入口</h3>
-                    <p className="text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-                      这里把查看当前登录密码、修改密码，以及身份页的基本说明收进一个入口，避免顶部像几块独立拼图一样散开。
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2 text-[11px]">
-                <span className="rounded-full border border-gray-200 dark:border-gray-700 px-3 py-1 text-gray-500 dark:text-gray-400">
-                  文档数 {identityDocs.length}
-                </span>
-                <span className="rounded-full border border-gray-200 dark:border-gray-700 px-3 py-1 text-gray-500 dark:text-gray-400">
-                  当前 {selectedIdentityDoc?.name || '未选择'}
-                </span>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)] gap-5">
-              <div className="space-y-4">
-                <div className="rounded-[24px] border border-blue-100/80 dark:border-blue-900/40 bg-[linear-gradient(145deg,rgba(255,255,255,0.92),rgba(239,246,255,0.7))] dark:bg-[linear-gradient(145deg,rgba(12,24,42,0.84),rgba(30,64,175,0.12))] p-5 space-y-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-500/80">当前登录凭证</div>
-                      <div className="mt-1 text-sm font-semibold text-gray-900 dark:text-white">管理后台登录密码</div>
-                    </div>
-                    <div className="rounded-full border border-blue-200/70 dark:border-blue-800/40 px-3 py-1 text-[11px] text-blue-600 dark:text-blue-300">
-                      `.env` / `ADMIN_TOKEN`
-                    </div>
-                  </div>
-                  <AdminPasswordField token={adminToken} onCopy={() => { setMsg('密码已复制'); setTimeout(() => setMsg(''), 2000); }} />
-                  <p className="text-xs text-gray-500 flex items-center gap-1.5">
-                    <span className="w-1 h-1 rounded-full bg-gray-400"></span>
-                    仅用于当前面板管理后台登录，不影响 OpenClaw 自身的 provider / gateway 配置。
-                  </p>
-                </div>
-                <div className="rounded-[24px] border border-gray-100 dark:border-gray-800 bg-gray-50/75 dark:bg-gray-900/40 p-4">
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="rounded-xl border border-white/80 dark:border-gray-800 bg-white/80 dark:bg-gray-950/30 px-3 py-3">
-                      <div className="text-[11px] text-gray-500">编辑顺序</div>
-                      <div className="mt-1 text-xs leading-relaxed text-gray-700 dark:text-gray-200">先改基础身份与登录入口，再处理文档内容。</div>
-                    </div>
-                    <div className="rounded-xl border border-white/80 dark:border-gray-800 bg-white/80 dark:bg-gray-950/30 px-3 py-3">
-                      <div className="text-[11px] text-gray-500">页面目标</div>
-                      <div className="mt-1 text-xs leading-relaxed text-gray-700 dark:text-gray-200">把“看密码、改密码、改人格”分出清晰层次。</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="rounded-[24px] border border-gray-100 dark:border-gray-800 bg-white/90 dark:bg-slate-900/55 p-5">
-                <ChangePasswordSection embedded />
-              </div>
-            </div>
-          </div>
-
           <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1.35fr),minmax(320px,0.95fr)] gap-6 items-start">
             <div className="space-y-4">
               <div className={`${modern ? 'page-modern-panel p-5' : 'bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/50 p-5'} space-y-4`}>
@@ -2320,25 +2252,6 @@ export default function SystemConfig() {
       )}
 
       {/* Docs tab removed — merged into Identity & 文档 tab */}
-    </div>
-  );
-}
-
-function AdminPasswordField({ token, onCopy }: { token: string; onCopy: () => void }) {
-  const [visible, setVisible] = useState(false);
-  return (
-    <div className="flex items-center gap-2">
-      <div className="relative flex-1">
-        <input type={visible ? 'text' : 'password'} readOnly value={token}
-          className="w-full pl-3 pr-10 py-2 text-xs border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 font-mono text-gray-600 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" />
-        <button onClick={() => setVisible(!visible)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors">
-          {visible ? <EyeOff size={14} /> : <Eye size={14} />}
-        </button>
-      </div>
-      <button onClick={() => { navigator.clipboard.writeText(token); onCopy(); }}
-        className="px-3 py-2 text-xs font-medium rounded-lg bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors border border-blue-100 dark:border-blue-800/30">
-        复制
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- align Hermes platform management with the OpenClaw channel experience, including shared field rendering, platform-specific forms, sidebar/overview fixes, and panel-level settings entry points
- harden Lite deployment by moving data to an external persistent directory so upgrades no longer wipe local state, while keeping the installer compatible across Linux, macOS, and Windows
- improve panel chat and runtime compatibility with newer OpenClaw builds, including safe config sanitization, incremental group-chat persistence, and summary-after-workers ordering

## Verification
- `go build ./cmd/clawpanel`
- `npm run build`
- exercised panel chat group session through the panel API with `coding-engineer`, `docs-planner`, and `qa-reviewer`