### PR TITLE
fix: stabilize workflow model resolution and task list for issue #130

### DIFF
--- a/internal/handler/openclaw.go
+++ b/internal/handler/openclaw.go
@@ -304,18 +304,34 @@ func injectWecomVirtualChannel(cfg *config.Config, ocConfig map[string]interface
 }
 
 func detectOpenClawPackageRoot() string {
-	bin, err := exec.LookPath("openclaw")
-	if err != nil {
-		return ""
+	candidates := []string{}
+	if p := config.DetectOpenClawBinaryPath(); strings.TrimSpace(p) != "" {
+		candidates = append(candidates, p)
 	}
-	resolved, err := filepath.EvalSymlinks(bin)
-	if err != nil {
-		resolved = bin
-	}
-	if strings.HasSuffix(resolved, ".mjs") || strings.HasSuffix(resolved, ".js") {
+	candidates = append(candidates, "openclaw")
+	for _, bin := range candidates {
+		bin = strings.TrimSpace(bin)
+		if bin == "" {
+			continue
+		}
+		resolvedPath := bin
+		if !filepath.IsAbs(bin) {
+			lookedUp, err := exec.LookPath(bin)
+			if err != nil {
+				continue
+			}
+			resolvedPath = lookedUp
+		}
+		resolved, err := filepath.EvalSymlinks(resolvedPath)
+		if err != nil {
+			resolved = resolvedPath
+		}
+		if strings.HasSuffix(resolved, ".mjs") || strings.HasSuffix(resolved, ".js") {
+			return filepath.Dir(resolved)
+		}
 		return filepath.Dir(resolved)
 	}
-	return filepath.Dir(resolved)
+	return ""
 }
 
 func detectBundledExtensionsDir() string {

--- a/internal/handler/openclaw_tasks.go
+++ b/internal/handler/openclaw_tasks.go
@@ -121,6 +121,27 @@ func sortOpenClawTasksByReferenceDesc(tasks []openClawTaskRecord) {
 	})
 }
 
+func dedupeOpenClawTasksByID(tasks []openClawTaskRecord) []openClawTaskRecord {
+	if len(tasks) <= 1 {
+		return tasks
+	}
+	seen := make(map[string]struct{}, len(tasks))
+	deduped := make([]openClawTaskRecord, 0, len(tasks))
+	for _, task := range tasks {
+		taskID := strings.TrimSpace(task.TaskID)
+		if taskID == "" {
+			deduped = append(deduped, task)
+			continue
+		}
+		if _, ok := seen[taskID]; ok {
+			continue
+		}
+		seen[taskID] = struct{}{}
+		deduped = append(deduped, task)
+	}
+	return deduped
+}
+
 func taskStatusTitle(task openClawTaskRecord) string {
 	if strings.TrimSpace(task.Label) != "" {
 		return strings.TrimSpace(task.Label)
@@ -315,6 +336,7 @@ func GetOpenClawTasks(cfg *config.Config) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": err.Error()})
 			return
 		}
+		records = dedupeOpenClawTasksByID(records)
 		now := time.Now()
 		summary := summarizeOpenClawTasks(records, now)
 		visible := make([]openClawTaskRecord, 0, len(records))

--- a/internal/handler/openclaw_tasks_test.go
+++ b/internal/handler/openclaw_tasks_test.go
@@ -1,0 +1,24 @@
+package handler
+
+import "testing"
+
+func TestDedupeOpenClawTasksByID(t *testing.T) {
+	t.Parallel()
+
+	in := []openClawTaskRecord{
+		{TaskID: "task-1", Status: "running", CreatedAt: 300},
+		{TaskID: "task-1", Status: "failed", CreatedAt: 200},
+		{TaskID: "task-2", Status: "queued", CreatedAt: 100},
+	}
+
+	got := dedupeOpenClawTasksByID(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 records after dedupe, got %d", len(got))
+	}
+	if got[0].TaskID != "task-1" || got[0].Status != "running" {
+		t.Fatalf("expected first/latest task-1 to be kept, got %#v", got[0])
+	}
+	if got[1].TaskID != "task-2" {
+		t.Fatalf("expected task-2 to remain, got %#v", got[1])
+	}
+}

--- a/internal/handler/workflows.go
+++ b/internal/handler/workflows.go
@@ -2575,7 +2575,7 @@ func (rt *workflowRuntime) workflowImageProviderConfig(step *model.WorkflowStep)
 		if value := strings.TrimSpace(toStringLocal(step.Input["baseUrl"])); value != "" {
 			baseURL = value
 		}
-		if value := strings.TrimSpace(toStringLocal(step.Input["apiKey"])); value != "" {
+		if value := resolveWorkflowAPIKey(step.Input["apiKey"]); value != "" {
 			apiKey = value
 		}
 		if value := strings.TrimSpace(toStringLocal(step.Input["model"])); value != "" {
@@ -2601,7 +2601,7 @@ func (rt *workflowRuntime) workflowImageProviderConfig(step *model.WorkflowStep)
 		baseURL = strings.TrimSpace(toStringLocal(provider["baseUrl"]))
 	}
 	if apiKey == "" {
-		apiKey = strings.TrimSpace(toStringLocal(provider["apiKey"]))
+		apiKey = resolveWorkflowAPIKey(provider["apiKey"])
 	}
 	if baseURL == "" || apiKey == "" {
 		return "", "", "", fmt.Errorf("workflow image provider incomplete: %s", providerID)
@@ -3075,28 +3075,13 @@ func (rt *workflowRuntime) callWorkflowModel(messages []map[string]string) (stri
 	}
 	models, _ := ocConfig["models"].(map[string]interface{})
 	providers, _ := models["providers"].(map[string]interface{})
-	pid := strings.TrimSpace(settings.ProviderID)
-	mid := strings.TrimSpace(settings.ModelID)
-	if pid == "" || mid == "" {
-		if agents, ok := ocConfig["agents"].(map[string]interface{}); ok {
-			if defaults, ok := agents["defaults"].(map[string]interface{}); ok {
-				if modelCfg, ok := defaults["model"].(map[string]interface{}); ok {
-					if primary, ok := modelCfg["primary"].(string); ok {
-						parts := strings.SplitN(primary, "/", 2)
-						if len(parts) == 2 {
-							pid, mid = parts[0], parts[1]
-						}
-					}
-				}
-			}
-		}
-	}
+	pid, mid := resolveWorkflowModelSelection(settings, ocConfig)
 	provider, ok := providers[pid].(map[string]interface{})
 	if !ok {
 		return "", nil, fmt.Errorf("workflow provider not found: %s", pid)
 	}
 	baseURL, _ := provider["baseUrl"].(string)
-	apiKey, _ := provider["apiKey"].(string)
+	apiKey := resolveWorkflowAPIKey(provider["apiKey"])
 	apiType, _ := provider["api"].(string)
 	if apiType == "" {
 		apiType = "openai-completions"
@@ -3354,6 +3339,133 @@ func normalizeWorkflowUserReply(v interface{}) string {
 		return ""
 	default:
 		return reply
+	}
+}
+
+func parseProviderModelID(raw interface{}) string {
+	switch m := raw.(type) {
+	case string:
+		return strings.TrimSpace(m)
+	case map[string]interface{}:
+		return strings.TrimSpace(toStringLocal(m["id"]))
+	default:
+		return ""
+	}
+}
+
+func resolveWorkflowModelSelection(settings *model.WorkflowSettings, ocConfig map[string]interface{}) (string, string) {
+	pid := strings.TrimSpace(settings.ProviderID)
+	mid := strings.TrimSpace(settings.ModelID)
+
+	if pid == "" || mid == "" {
+		agents, _ := ocConfig["agents"].(map[string]interface{})
+		defaults, _ := agents["defaults"].(map[string]interface{})
+		switch modelCfg := defaults["model"].(type) {
+		case string:
+			primary := strings.TrimSpace(modelCfg)
+			parts := strings.SplitN(primary, "/", 2)
+			if len(parts) == 2 {
+				if pid == "" {
+					pid = strings.TrimSpace(parts[0])
+				}
+				if mid == "" {
+					mid = strings.TrimSpace(parts[1])
+				}
+			}
+		case map[string]interface{}:
+			primary := strings.TrimSpace(toStringLocal(modelCfg["primary"]))
+			parts := strings.SplitN(primary, "/", 2)
+			if len(parts) == 2 {
+				if pid == "" {
+					pid = strings.TrimSpace(parts[0])
+				}
+				if mid == "" {
+					mid = strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+
+	models, _ := ocConfig["models"].(map[string]interface{})
+	providers, _ := models["providers"].(map[string]interface{})
+
+	if pid != "" && mid == "" {
+		if provider, ok := providers[pid].(map[string]interface{}); ok {
+			if modelItems, ok := provider["models"].([]interface{}); ok {
+				for _, item := range modelItems {
+					if candidate := parseProviderModelID(item); candidate != "" {
+						mid = candidate
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if pid == "" && mid != "" {
+		for providerID, rawProvider := range providers {
+			provider, _ := rawProvider.(map[string]interface{})
+			if provider == nil {
+				continue
+			}
+			modelItems, _ := provider["models"].([]interface{})
+			for _, item := range modelItems {
+				if parseProviderModelID(item) == mid {
+					pid = strings.TrimSpace(providerID)
+					break
+				}
+			}
+			if pid != "" {
+				break
+			}
+		}
+	}
+
+	if pid == "" && mid == "" && len(providers) == 1 {
+		for providerID, rawProvider := range providers {
+			pid = strings.TrimSpace(providerID)
+			provider, _ := rawProvider.(map[string]interface{})
+			if provider == nil {
+				break
+			}
+			if modelItems, ok := provider["models"].([]interface{}); ok {
+				for _, item := range modelItems {
+					if candidate := parseProviderModelID(item); candidate != "" {
+						mid = candidate
+						break
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return pid, mid
+}
+
+func resolveWorkflowAPIKey(raw interface{}) string {
+	switch v := raw.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case map[string]interface{}:
+		if value := strings.TrimSpace(toStringLocal(v["value"])); value != "" {
+			return value
+		}
+		if value := strings.TrimSpace(toStringLocal(v["raw"])); value != "" {
+			return value
+		}
+		for _, key := range []string{"env", "fromEnv", "envVar", "name"} {
+			if envKey := strings.TrimSpace(toStringLocal(v[key])); envKey != "" {
+				if value := strings.TrimSpace(os.Getenv(envKey)); value != "" {
+					return value
+				}
+			}
+		}
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
 	}
 }
 

--- a/internal/handler/workflows_model_test.go
+++ b/internal/handler/workflows_model_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"os"
+	"testing"
+
+	"github.com/zhaoxinyi02/ClawPanel/internal/model"
+)
+
+func TestResolveWorkflowModelSelectionFromDefaultsString(t *testing.T) {
+	t.Parallel()
+
+	settings := &model.WorkflowSettings{}
+	ocConfig := map[string]interface{}{
+		"agents": map[string]interface{}{
+			"defaults": map[string]interface{}{
+				"model": "openai/gpt-5.4",
+			},
+		},
+		"models": map[string]interface{}{
+			"providers": map[string]interface{}{
+				"openai": map[string]interface{}{
+					"models": []interface{}{"gpt-5.4"},
+				},
+			},
+		},
+	}
+
+	pid, mid := resolveWorkflowModelSelection(settings, ocConfig)
+	if pid != "openai" || mid != "gpt-5.4" {
+		t.Fatalf("expected openai/gpt-5.4, got %q/%q", pid, mid)
+	}
+}
+
+func TestResolveWorkflowModelSelectionFillsMissingModelID(t *testing.T) {
+	t.Parallel()
+
+	settings := &model.WorkflowSettings{ProviderID: "openai", ModelID: ""}
+	ocConfig := map[string]interface{}{
+		"models": map[string]interface{}{
+			"providers": map[string]interface{}{
+				"openai": map[string]interface{}{
+					"models": []interface{}{
+						map[string]interface{}{"id": "gpt-5.4"},
+					},
+				},
+			},
+		},
+	}
+
+	pid, mid := resolveWorkflowModelSelection(settings, ocConfig)
+	if pid != "openai" || mid != "gpt-5.4" {
+		t.Fatalf("expected openai/gpt-5.4, got %q/%q", pid, mid)
+	}
+}
+
+func TestResolveWorkflowAPIKeyFromEnvObject(t *testing.T) {
+	t.Parallel()
+
+	const envKey = "CLAWPANEL_WORKFLOW_TEST_KEY"
+	if err := os.Setenv(envKey, "env-secret"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Unsetenv(envKey) })
+
+	got := resolveWorkflowAPIKey(map[string]interface{}{"env": envKey})
+	if got != "env-secret" {
+		t.Fatalf("expected env-secret, got %q", got)
+	}
+}
+
+func TestResolveWorkflowAPIKeyFromValueObject(t *testing.T) {
+	t.Parallel()
+
+	got := resolveWorkflowAPIKey(map[string]interface{}{"value": "inline-secret"})
+	if got != "inline-secret" {
+		t.Fatalf("expected inline-secret, got %q", got)
+	}
+}

--- a/web/src/pages/SystemConfig.tsx
+++ b/web/src/pages/SystemConfig.tsx
@@ -981,12 +981,12 @@ export default function SystemConfig() {
             {Object.entries(providers).map(([pid, prov]: [string, any]) => (
               <div key={pid} className={`${modern ? 'page-modern-panel overflow-hidden transition-all hover:shadow-md' : 'bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/50 overflow-hidden transition-all hover:shadow-md'}`}>
                 <div className="p-5 space-y-5">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
                         <div className="p-2 rounded-xl border border-blue-100/80 dark:border-blue-800/40 bg-[linear-gradient(135deg,rgba(37,99,235,0.12),rgba(14,165,233,0.08))] dark:bg-[linear-gradient(135deg,rgba(37,99,235,0.2),rgba(14,165,233,0.12))] text-blue-600 dark:text-blue-300">
                           <Brain size={18} />
                         </div>
-                      <div className="flex items-baseline gap-2">
+                      <div className="flex min-w-0 flex-wrap items-baseline gap-2">
                         <input value={pid} onChange={e => {
                           const newId = e.target.value;
                           if (!newId || newId === pid) return;
@@ -1004,7 +1004,7 @@ export default function SystemConfig() {
                             clone.agents.defaults.model.primary = newId + primary.slice(pid.length);
                           }
                           });
-                        }} className="text-base font-bold bg-transparent border-b border-dashed border-gray-300 dark:border-gray-600 focus:border-blue-500 outline-none px-1 py-0.5 min-w-[120px] transition-colors text-gray-900 dark:text-white" title="点击编辑 Provider ID" />
+                        }} className="text-base font-bold bg-transparent border-b border-dashed border-gray-300 dark:border-gray-600 focus:border-blue-500 outline-none px-1 py-0.5 min-w-[120px] max-w-full transition-colors text-gray-900 dark:text-white" title="点击编辑 Provider ID" />
                         {prov.models?.length > 0 && <span className="text-xs text-gray-400 font-medium px-2 py-0.5 bg-gray-50 dark:bg-gray-800 rounded-full">{prov.models.length} 模型</span>}
                       </div>
                     </div>
@@ -1012,7 +1012,7 @@ export default function SystemConfig() {
                       updateConfig((clone: any) => {
                         delete clone.models.providers[pid];
                       });
-                    }} className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"><Trash2 size={16} /></button>
+                    }} className="shrink-0 p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"><Trash2 size={16} /></button>
                   </div>
 
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-5">


### PR DESCRIPTION
### What
- Improve OpenClaw binary discovery fallback to reduce "openclaw command not found"
- Fix workflow model selection fallback (support `agents.defaults.model` string and partial settings)
- Support workflow API key resolution from secret object/env in addition to plain string
- Dedupe OpenClaw task records by `taskId` before returning to UI
- Make provider card header responsive so action button stays visible on narrower layouts
- Add focused tests for workflow model/API-key resolution and task dedupe

Closes #130