### PR TITLE
fix: improve panel chat realtime updates and reply reliability (fix #134)

### DIFF
--- a/internal/handler/panel_chat.go
+++ b/internal/handler/panel_chat.go
@@ -706,14 +706,7 @@ func extractPanelChatPayloads(content interface{}) (string, []map[string]string)
 	return text, images
 }
 
-func readPanelChatMessages(cfg *config.Config, session panelChatSession) ([]map[string]interface{}, error) {
-	localMessages, err := loadPanelChatMessages(cfg, session.ID)
-	if err != nil {
-		return nil, err
-	}
-	if len(localMessages) > 0 {
-		return localMessages, nil
-	}
+func readPanelChatRuntimeMessages(cfg *config.Config, session panelChatSession) ([]map[string]interface{}, error) {
 	filePath := panelChatSessionFile(cfg, session.AgentID, session.OpenClawSessionID)
 	if _, err := os.Stat(filePath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -788,6 +781,24 @@ func readPanelChatMessages(cfg *config.Config, session panelChatSession) ([]map[
 		messages = messages[len(messages)-400:]
 	}
 	return messages, nil
+}
+
+func readPanelChatMessages(cfg *config.Config, session panelChatSession) ([]map[string]interface{}, error) {
+	localMessages, err := loadPanelChatMessages(cfg, session.ID)
+	if err != nil {
+		return nil, err
+	}
+	runtimeMessages, err := readPanelChatRuntimeMessages(cfg, session)
+	if err != nil {
+		return nil, err
+	}
+	if len(localMessages) == 0 {
+		return runtimeMessages, nil
+	}
+	if len(runtimeMessages) == 0 {
+		return localMessages, nil
+	}
+	return mergePanelChatTranscripts(localMessages, runtimeMessages), nil
 }
 
 func resolvePanelChatCommand(cfg *config.Config) (string, []string, error) {

--- a/internal/handler/panel_chat_test.go
+++ b/internal/handler/panel_chat_test.go
@@ -315,3 +315,53 @@ func TestRewritePanelChatRuntimeConfigPreservesConfiguredWorkspace(t *testing.T)
 		t.Fatalf("expected workspace %q, got %#v", filepath.ToSlash(workspace), got)
 	}
 }
+
+func TestReadPanelChatMessagesMergesRuntimeWithLocalHistory(t *testing.T) {
+	cfg := newPanelChatTestConfig(t)
+	session := panelChatSession{
+		ID:                "panel-merge",
+		OpenClawSessionID: "panel-merge",
+		AgentID:           "main",
+		ChatType:          "direct",
+		Title:             "merge",
+		CreatedAt:         time.Now().UnixMilli(),
+		UpdatedAt:         time.Now().UnixMilli(),
+	}
+
+	localMessages := []map[string]interface{}{
+		{
+			"id":         "user-1",
+			"role":       "user",
+			"senderType": "user",
+			"content":    "hello",
+			"timestamp":  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	if err := savePanelChatMessages(cfg, session.ID, localMessages); err != nil {
+		t.Fatalf("savePanelChatMessages failed: %v", err)
+	}
+
+	runtimeFile := panelChatSessionFile(cfg, session.AgentID, session.OpenClawSessionID)
+	if err := os.MkdirAll(filepath.Dir(runtimeFile), 0o755); err != nil {
+		t.Fatalf("mkdir runtime dir failed: %v", err)
+	}
+	runtimeLine := `{"id":"assistant-1","type":"assistant","timestamp":"` + time.Now().UTC().Format(time.RFC3339) + `","message":{"role":"assistant","content":[{"type":"text","text":"world"}]}}`
+	if err := os.WriteFile(runtimeFile, []byte(runtimeLine+"\n"), 0o644); err != nil {
+		t.Fatalf("write runtime file failed: %v", err)
+	}
+
+	messages, err := readPanelChatMessages(cfg, session)
+	if err != nil {
+		t.Fatalf("readPanelChatMessages failed: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected merged 2 messages, got %d (%#v)", len(messages), messages)
+	}
+	last := messages[len(messages)-1]
+	if got, _ := last["role"].(string); got != "assistant" {
+		t.Fatalf("expected assistant runtime message, got %#v", last)
+	}
+	if got := strings.TrimSpace(toString(last["content"])); got != "world" {
+		t.Fatalf("expected runtime content world, got %#v", last["content"])
+	}
+}

--- a/web/src/pages/PanelChat.tsx
+++ b/web/src/pages/PanelChat.tsx
@@ -423,6 +423,14 @@ export default function PanelChat() {
     const message = input.trim();
     if (!message || loading) return;
     let sessionId = selectedId;
+    let livePollTimer: number | null = null;
+    let livePollBusy = false;
+    const stopLivePoll = () => {
+      if (livePollTimer !== null) {
+        window.clearInterval(livePollTimer);
+        livePollTimer = null;
+      }
+    };
     const requestId = activeRequestIdRef.current + 1;
     activeRequestIdRef.current = requestId;
     setErrorText('');
@@ -439,6 +447,20 @@ export default function PanelChat() {
         sessionId,
       });
       setProcessingSessionId(sessionId);
+      livePollTimer = window.setInterval(() => {
+        if (activeRequestIdRef.current !== requestId || livePollBusy) return;
+        livePollBusy = true;
+        void api.getPanelChatSessionDetail(sessionId as string).then(detail => {
+          if (activeRequestIdRef.current !== requestId || !detail?.ok) return;
+          if (selectedIdRef.current === sessionId) {
+            setMessages(Array.isArray(detail.messages) ? detail.messages : []);
+            setParticipants(Array.isArray(detail.participants) ? detail.participants : []);
+            setPendingUserMessage(null);
+          }
+        }).finally(() => {
+          livePollBusy = false;
+        });
+      }, 1200);
       const controller = new AbortController();
       abortControllerRef.current = controller;
       const token = localStorage.getItem('admin-token') || '';
@@ -454,6 +476,7 @@ export default function PanelChat() {
       const res = await response.json();
       abortControllerRef.current = null;
       if (activeRequestIdRef.current !== requestId) return;
+      stopLivePoll();
       if (res?.ok) {
         abortMarkerHandledRef.current[sessionId] = false;
         if (selectedIdRef.current === sessionId) {
@@ -472,6 +495,7 @@ export default function PanelChat() {
       }
     } catch (error: any) {
       abortControllerRef.current = null;
+      stopLivePoll();
       if (activeRequestIdRef.current !== requestId) return;
       if (error?.name === 'AbortError') {
         if (sessionId) appendAbortMarker(sessionId);
@@ -481,6 +505,7 @@ export default function PanelChat() {
       setInput(message);
       setErrorText(text.failedSend);
     } finally {
+      stopLivePoll();
       if (activeRequestIdRef.current !== requestId) return;
       if (sessionId) {
         if (!processingSessionId || processingSessionId === sessionId) abortMarkerHandledRef.current[sessionId] = false;


### PR DESCRIPTION
### What
- Merge runtime transcript with persisted panel-chat history so in-flight assistant outputs can be observed earlier
- Poll session detail while a message is being processed to refresh timeline continuously
- Keep existing response contract while improving perceived realtime behavior in ClawPanel panel chat
- Add regression test for runtime/local transcript merge

### Why
Issue #134 reports that OpenClaw native panel chat can return in realtime while ClawPanel panel chat may appear to not reply. This change improves incremental visibility and reduces stalled/no-reply perception.

Closes #134